### PR TITLE
Add details for running against pipenv projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,48 @@ $ pip-audit --no-deps -r requirements.txt
 $ pip-audit --require-hashes -r requirements.txt
 ```
 
+### Running against pipenv project
+
+pipenv uses both a `Pipfile` and `Pipfile.lock` file to track and freeze dependencies
+instead of a `requirements.txt` file. `pip-audit` cannot process the `Pipfile[.lock]`
+files directly, however, these can be converted to a supported `requirements.txt` file
+that pip-audit can run against. Use a Python tool, such as
+[`pipfile-requirements`](https://github.com/frostming/pipfile-requirements), to
+convert your `Pipfile[.lock]` to a `requirements.txt` file and then run
+`pip-audit` against the generated requirements file.
+
+```console
+# install pipfile-requirements
+$ pipenv install --dev pipfile-requirements
+
+# Convert the Pipfile.lock to requirements.txt
+$ pipenv run pipfile2req Pipfile.lock > requirements.txt
+
+# Run pip-audit against the generated requirements.txt
+$ pipenv run pip-audit -r requirements.txt
+```
+
+The `requirements.txt` file needs to be kept up to date with pipenv When running
+`pip-audit` locally like this. Alternatively, this can be completed in GitHub CI by
+adding this step prior to the `pip-audit` action:
+
+```yaml
+jobs:
+  pip-audit:
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9  # change to your required version of Python
+
+      - name: 'Generate requirements.txt'
+        run: |
+          pipx run pipfile-requirements Pipfile.lock > requirements.txt
+
+      - uses: pypa/gh-action-pip-audit@v1.0.0
+        with:
+          inputs: requirements.txt
+```
+
 ## Security Model
 
 This section exists to describe the security assumptions you **can** and **must not**

--- a/README.md
+++ b/README.md
@@ -393,13 +393,8 @@ convert your `Pipfile[.lock]` to a `requirements.txt` file and then run
 `pip-audit` against the generated requirements file.
 
 ```console
-# install pipfile-requirements
 $ pipenv install --dev pipfile-requirements
-
-# Convert the Pipfile.lock to requirements.txt
 $ pipenv run pipfile2req Pipfile.lock > requirements.txt
-
-# Run pip-audit against the generated requirements.txt
 $ pipenv run pip-audit -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -382,12 +382,12 @@ $ pip-audit --require-hashes -r requirements.txt
 
 ## Tips and Tricks
 
-### Running against a pipenv project
+### Running against a `pipenv` project
 
-pipenv uses both a `Pipfile` and `Pipfile.lock` file to track and freeze dependencies
+`pipenv` uses both a `Pipfile` and `Pipfile.lock` file to track and freeze dependencies
 instead of a `requirements.txt` file. `pip-audit` cannot process the `Pipfile[.lock]`
 files directly, however, these can be converted to a supported `requirements.txt` file
-that pip-audit can run against. Use a Python tool, such as
+that `pip-audit` can run against. Use a Python tool, such as
 [`pipfile-requirements`](https://github.com/frostming/pipfile-requirements), to
 convert your `Pipfile[.lock]` to a `requirements.txt` file and then run
 `pip-audit` against the generated requirements file.
@@ -403,7 +403,7 @@ $ pipenv run pipfile2req Pipfile.lock > requirements.txt
 $ pipenv run pip-audit -r requirements.txt
 ```
 
-The `requirements.txt` file needs to be kept up to date with pipenv when running
+The `requirements.txt` file needs to be kept up to date with `pipenv` when running
 `pip-audit` locally like this.
 
 ## Security Model

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ with support from Google. This is not an official Google or Trail of Bits produc
   * [Dry runs](#dry-runs)
 * [Examples](#examples)
 * [Troubleshooting](#troubleshooting)
+* [Tips and Tricks](#tips-and-tricks)
 * [Security model](#security-model)
 * [Licensing](#licensing)
 * [Contributing](#contributing)
@@ -379,7 +380,9 @@ $ pip-audit --no-deps -r requirements.txt
 $ pip-audit --require-hashes -r requirements.txt
 ```
 
-### Running against pipenv project
+## Tips and Tricks
+
+### Running against a pipenv project
 
 pipenv uses both a `Pipfile` and `Pipfile.lock` file to track and freeze dependencies
 instead of a `requirements.txt` file. `pip-audit` cannot process the `Pipfile[.lock]`
@@ -400,26 +403,8 @@ $ pipenv run pipfile2req Pipfile.lock > requirements.txt
 $ pipenv run pip-audit -r requirements.txt
 ```
 
-The `requirements.txt` file needs to be kept up to date with pipenv When running
-`pip-audit` locally like this. Alternatively, this can be completed in GitHub CI by
-adding this step prior to the `pip-audit` action:
-
-```yaml
-jobs:
-  pip-audit:
-    steps:
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9  # change to your required version of Python
-
-      - name: 'Generate requirements.txt'
-        run: |
-          pipx run pipfile-requirements Pipfile.lock > requirements.txt
-
-      - uses: pypa/gh-action-pip-audit@v1.0.0
-        with:
-          inputs: requirements.txt
-```
+The `requirements.txt` file needs to be kept up to date with pipenv when running
+`pip-audit` locally like this.
 
 ## Security Model
 


### PR DESCRIPTION
I have a pipenv project that I wanted to run pip-audit against. I found a simple workaround to convert the `Pipfile[.lock]` to a compatible `requirements.txt` file that pip-audit can process. I documented how I got this working in hopes it can help others with pipenv based projects. I've verified that the commands I added work properly, for both running locally and within GitHub CI.

Refs #85