### PR TITLE
workflows/release: update gh-action-sigstore-python ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
 
     - name: sign
-      uses: trailofbits/gh-action-sigstore-python@v0.0.9
+      uses: sigstore/gh-action-sigstore-python@v0.0.9
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
         release-signing-artifacts: true


### PR DESCRIPTION
Now that we've reorg'd under the Sigstore org.

Signed-off-by: William Woodruff <william@trailofbits.com>