### PR TITLE
requirement: handle VCS URLs correctly in pinned mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ All versions prior to 0.0.9 are untracked.
   were not correctly filtered by "withdrawn" status; "withdrawn" vulnerabilities
   are now excluded ([#386](https://github.com/pypa/pip-audit/pull/386))
 
-* Fixed the `pip-audit` CLI's error handling for URL requirements
-  specifications when being run in a "pinned" requirements mode
-  (i.e. `--no-deps` or `--require-hashes`)
+* Fixed `pip-audit`'s handling of URL-style requirements in `--no-deps` mode
+  (URL requirements are now treated as skipped, rather than producing
+  an error due to a lack of pinning)
   ([#395](https://github.com/pypa/pip-audit/pull/395/files))
 
 ## [2.4.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All versions prior to 0.0.9 are untracked.
   were not correctly filtered by "withdrawn" status; "withdrawn" vulnerabilities
   are now excluded ([#386](https://github.com/pypa/pip-audit/pull/386))
 
+* Fixed the `pip-audit` CLI's error handling for URL requirements
+  specifications when being run in a "pinned" requirements mode
+  (i.e. `--no-deps` or `--require-hashes`)
+  ([#395](https://github.com/pypa/pip-audit/pull/395/files))
+
 ## [2.4.4]
 
 ### Changed

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -448,6 +448,8 @@ def audit() -> None:
                 if len(vulns) > 0:
                     pkg_count += 1
                     vuln_count += len(vulns)
+        except DependencySourceError as e:
+            _fatal(str(e))
         except VulnServiceConnectionError as e:
             # The most common source of connection errors is corporate blocking,
             # so we offer a bit of advice.

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -250,25 +250,30 @@ class RequirementSource(DependencySource):
                     f"requirement {req.name} does not contain a hash {str(req)}"
                 )
 
-            if not req.specifier:
-                if not req.is_url:
+            # NOTE: URL dependencies cannot be pinned, so skipping them
+            # makes sense (under the same principle of skipping dependencies
+            # that can't be found on PyPI). This is also consistent with
+            # what `pip --no-deps` does (installs the URL dependency, but
+            # not any subdependencies).
+            if req.is_url:
+                yield req.req, SkippedDependency(
+                    name=req.name,
+                    skip_reason="URL requirements cannot be pinned to a specific package version",
+                )
+            elif not req.specifier:
+                raise RequirementSourceError(f"requirement {req.name} is not pinned: {str(req)}")
+            else:
+                pinned_specifier = PINNED_SPECIFIER_RE.match(str(req.specifier))
+                if pinned_specifier is None:
                     raise RequirementSourceError(
                         f"requirement {req.name} is not pinned: {str(req)}"
                     )
-                else:
-                    raise RequirementSourceError(
-                        f"requirement {req.name} is a URL, and URL requirements cannot be pinned"
-                    )
 
-            pinned_specifier = PINNED_SPECIFIER_RE.match(str(req.specifier))
-            if pinned_specifier is None:
-                raise RequirementSourceError(f"requirement {req.name} is not pinned: {str(req)}")
-
-            yield req.req, ResolvedDependency(
-                req.name,
-                Version(pinned_specifier.group("version")),
-                self._build_hash_options_mapping(req.hash_options),
-            )
+                yield req.req, ResolvedDependency(
+                    req.name,
+                    Version(pinned_specifier.group("version")),
+                    self._build_hash_options_mapping(req.hash_options),
+                )
 
     def _build_hash_options_mapping(self, hash_options: List[str]) -> Dict[str, List[str]]:
         """

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -251,14 +251,13 @@ class RequirementSource(DependencySource):
                 )
 
             if not req.specifier:
-                if req.link is None:
+                if not req.is_url:
                     raise RequirementSourceError(
                         f"requirement {req.name} is not pinned: {str(req)}"
                     )
                 else:
                     raise RequirementSourceError(
-                        f"requirement {req.name} is not pinned, URL requirements must be pinned "
-                        f"with #egg=your_package_name==your_package_version: {str(req)}"
+                        f"requirement {req.name} is a URL, and URL requirements cannot be pinned"
                     )
 
             pinned_specifier = PINNED_SPECIFIER_RE.match(str(req.specifier))

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -451,13 +451,15 @@ def test_requirement_source_no_deps_unpinned_url(monkeypatch):
     monkeypatch.setattr(
         pip_requirements_parser,
         "get_file_content",
-        lambda _: "https://github.com/pallets/flask/archive/refs/tags/2.0.1.tar.gz#egg=flask\n"
-        "requests>=1.0",
+        lambda _: "https://github.com/pallets/flask/archive/refs/tags/2.0.1.tar.gz#egg=flask\n",
     )
 
-    # When dependency resolution is disabled, all requirements must be pinned.
-    with pytest.raises(DependencySourceError):
-        list(source.collect())
+    assert list(source.collect()) == [
+        SkippedDependency(
+            name="flask",
+            skip_reason="URL requirements cannot be pinned to a specific package version",
+        )
+    ]
 
 
 def test_requirement_source_dep_caching(monkeypatch):


### PR DESCRIPTION
This "fixes" #382 by:

~~1. Turning the unchecked exception into a controlled error~~
~~2. Fixing the error message (clarifying that `pip` doesn't support version pinning on URLs (VCS or otherwise), meaning that URL requirements cannot be used with `--no-deps` or `--require-hashes)~~

1. Explicitly skipping URL dependencies in `--no-deps` mode, which is compatible with how `pip --no-deps` behaves

Closes #382.