### PR TITLE
workflows/release: use `gh-action-pypi-publish@release/v1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       run: python -m build
 
     - name: publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Using `@master` isn't officially supported, so this just moves us to the supported release ref.

Signed-off-by: William Woodruff <william@trailofbits.com>