### PR TITLE
Add support for Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ with support from Google. This is not an official Google or Trail of Bits produc
 
 ## Features
 
-* Support for auditing local environments and requirements-style files
+* Support for auditing local environments, requirements-style files, and poetry.lock files.
 * Support for multiple vulnerability services
   ([PyPI](https://warehouse.pypa.io/api-reference/json.html#known-vulnerabilities),
   [OSV](https://osv.dev/docs/))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ with support from Google. This is not an official Google or Trail of Bits produc
 
 ## Features
 
-* Support for auditing local environments, requirements-style files, and poetry.lock files.
+* Support for auditing local environments, requirements-style files, and poetry.lock files
 * Support for multiple vulnerability services
   ([PyPI](https://warehouse.pypa.io/api-reference/json.html#known-vulnerabilities),
   [OSV](https://osv.dev/docs/))

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -17,6 +17,7 @@ from pip_audit._dependency_source import (
     PYPI_URL,
     DependencySource,
     PipSource,
+    PoetrySource,
     PyProjectSource,
     RequirementSource,
     ResolveLibResolver,
@@ -330,8 +331,14 @@ def _dep_source_from_project_path(
     project_path: Path, resolver: ResolveLibResolver, state: AuditState
 ) -> DependencySource:  # pragma: no cover
     # Check for a `pyproject.toml`
+    poetry_lock = project_path / "poetry.lock"
+    if poetry_lock.is_file():
+        logger.debug("using PoetrySource as dependency source")
+        return PoetrySource(path=poetry_lock)
+
     pyproject_path = project_path / "pyproject.toml"
     if pyproject_path.is_file():
+        logger.debug("using PyProjectSource as dependency source")
         return PyProjectSource(pyproject_path, resolver, state)
 
     # TODO: Checks for setup.py and other project files will go here.

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -330,7 +330,6 @@ def _parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:  # pragm
 def _dep_source_from_project_path(
     project_path: Path, resolver: ResolveLibResolver, state: AuditState
 ) -> DependencySource:  # pragma: no cover
-    # Check for a `pyproject.toml`
     poetry_lock = project_path / "poetry.lock"
     if poetry_lock.is_file():
         logger.debug("using PoetrySource as dependency source")

--- a/pip_audit/_dependency_source/__init__.py
+++ b/pip_audit/_dependency_source/__init__.py
@@ -10,6 +10,7 @@ from .interface import (
     DependencySourceError,
 )
 from .pip import PipSource, PipSourceError
+from .poetry import PoetrySource
 from .pyproject import PyProjectSource
 from .requirement import RequirementSource
 from .resolvelib import PYPI_URL, ResolveLibResolver
@@ -23,6 +24,7 @@ __all__ = [
     "DependencySourceError",
     "PipSource",
     "PipSourceError",
+    "PoetrySource",
     "PyProjectSource",
     "RequirementSource",
     "ResolveLibResolver",

--- a/pip_audit/_dependency_source/pip.py
+++ b/pip_audit/_dependency_source/pip.py
@@ -98,7 +98,6 @@ class PipSource(DependencySource):
                             "Package has invalid version and could not be audited: "
                             f"{dist.name} ({dist.version})"
                         )
-                        logger.debug(skip_reason)
                         dep = SkippedDependency(name=dist.name, skip_reason=skip_reason)
                 yield dep
         except Exception as e:

--- a/pip_audit/_dependency_source/poetry.py
+++ b/pip_audit/_dependency_source/poetry.py
@@ -11,7 +11,7 @@ from typing import Iterator
 import toml
 from packaging.version import InvalidVersion, Version
 
-from pip_audit._dependency_source import DependencySource
+from pip_audit._dependency_source import DependencyFixError, DependencySource
 from pip_audit._fix import ResolvedFixVersion
 from pip_audit._service import Dependency, ResolvedDependency, SkippedDependency
 
@@ -41,7 +41,6 @@ class PoetrySource(DependencySource):
                     "Package has invalid version and could not be audited: "
                     f"{name} ({package['version']})"
                 )
-                logger.debug(skip_reason)
                 yield SkippedDependency(name=name, skip_reason=skip_reason)
             else:
                 yield ResolvedDependency(name=name, version=version)
@@ -55,4 +54,4 @@ class PoetrySource(DependencySource):
         Note that poetry ignores the version we want to update to,
         and goes straight to the latest version allowed in metadata.
         """
-        raise NotImplementedError("fix is not supported for poetry yet")  # pragma: no cover
+        raise DependencyFixError("fix is not supported for poetry yet")  # pragma: no cover

--- a/pip_audit/_dependency_source/poetry.py
+++ b/pip_audit/_dependency_source/poetry.py
@@ -36,7 +36,7 @@ class PoetrySource(DependencySource):
             name = package["name"]
             try:
                 version = Version(package["version"])
-            except InvalidVersion:  # pragma: no cover
+            except InvalidVersion:
                 skip_reason = (
                     "Package has invalid version and could not be audited: "
                     f"{name} ({package['version']})"
@@ -55,4 +55,4 @@ class PoetrySource(DependencySource):
         Note that poetry ignores the version we want to update to,
         and goes straight to the latest version allowed in metadata.
         """
-        raise NotImplementedError("fix is not supported for poetry yet")
+        raise NotImplementedError("fix is not supported for poetry yet")  # pragma: no cover

--- a/pip_audit/_dependency_source/poetry.py
+++ b/pip_audit/_dependency_source/poetry.py
@@ -4,8 +4,6 @@ Collect dependencies from `poetry.lock` files.
 from __future__ import annotations
 
 import logging
-import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
@@ -57,8 +55,4 @@ class PoetrySource(DependencySource):
         Note that poetry ignores the version we want to update to,
         and goes straight to the latest version allowed in metadata.
         """
-        subprocess.run(
-            [sys.executable, "-m", "poetry", "update", "--lock", fix_version.dep.name],
-            cwd=self.path.parent,
-            stdout=subprocess.DEVNULL,
-        ).check_returncode()
+        raise NotImplementedError("fix is not supported for poetry yet")

--- a/pip_audit/_dependency_source/poetry.py
+++ b/pip_audit/_dependency_source/poetry.py
@@ -38,7 +38,7 @@ class PoetrySource(DependencySource):
             name = package["name"]
             try:
                 version = Version(package["version"])
-            except InvalidVersion:
+            except InvalidVersion:  # pragma: no cover
                 skip_reason = (
                     "Package has invalid version and could not be audited: "
                     f"{name} ({package['version']})"

--- a/pip_audit/_dependency_source/poetry.py
+++ b/pip_audit/_dependency_source/poetry.py
@@ -1,0 +1,64 @@
+"""
+Collect dependencies from `poetry.lock` files.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import toml
+from packaging.version import InvalidVersion, Version
+
+from pip_audit._dependency_source import DependencySource
+from pip_audit._fix import ResolvedFixVersion
+from pip_audit._service import Dependency, ResolvedDependency, SkippedDependency
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PoetrySource(DependencySource):
+    """
+    Dependency sourcing from `poetry.lock`.
+    """
+
+    path: Path
+
+    def collect(self) -> Iterator[Dependency]:
+        """
+        Collect all of the dependencies discovered by this `PoetrySource`.
+        """
+        with self.path.open("r") as stream:
+            packages = toml.load(stream)
+        for package in packages["package"]:
+            name = package["name"]
+            try:
+                version = Version(package["version"])
+            except InvalidVersion:
+                skip_reason = (
+                    "Package has invalid version and could not be audited: "
+                    f"{name} ({package['version']})"
+                )
+                logger.debug(skip_reason)
+                yield SkippedDependency(name=name, skip_reason=skip_reason)
+            else:
+                yield ResolvedDependency(name=name, version=version)
+
+    def fix(self, fix_version: ResolvedFixVersion) -> None:
+        """
+        Fixes a dependency version for this `PoetrySource`.
+
+        Requires poetry to be installed in the same env.
+
+        Note that poetry ignores the version we want to update to,
+        and goes straight to the latest version allowed in metadata.
+        """
+        subprocess.run(
+            [sys.executable, "-m", "poetry", "update", "--lock", fix_version.dep.name],
+            cwd=self.path.parent,
+            stdout=subprocess.DEVNULL,
+        ).check_returncode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ requires-python = ">=3.7"
 [project.optional-dependencies]
 test = [
     "coverage[toml]",
-    "poetry",
     "pretend",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ requires-python = ">=3.7"
 [project.optional-dependencies]
 test = [
     "coverage[toml]",
+    "poetry",
     "pretend",
     "pytest",
     "pytest-cov",

--- a/test/dependency_source/data/poetry.lock
+++ b/test/dependency_source/data/poetry.lock
@@ -1,0 +1,74 @@
+[[package]]
+name = "jinja2"
+version = "2.11.3"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "402680c1a5d5e2e2fa5cee9a848c87fde96bcb482137924a194e4d47920ec76f"
+
+[metadata.files]
+jinja2 = [
+    {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
+    {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]

--- a/test/dependency_source/test_poetry.py
+++ b/test/dependency_source/test_poetry.py
@@ -7,10 +7,8 @@ from textwrap import dedent
 from typing import Callable
 
 import pytest
-from packaging.version import Version
 
 from pip_audit._dependency_source import PoetrySource
-from pip_audit._fix import ResolvedFixVersion
 from pip_audit._service import ResolvedDependency
 
 
@@ -55,9 +53,3 @@ def test_collect_and_fix(lock: Callable) -> None:
     meta_content = meta_path.read_text()
     meta_content = meta_content.replace("2.7.1", "2.7.*")
     meta_path.write_text(meta_content)
-
-    # fix
-    sourcer.fix(ResolvedFixVersion(dep=deps[0], version=Version("2.7.3")))
-    content = lock_path.read_text()
-    assert 'version = "2.7.3"' in content
-    assert "2.7.1" not in content

--- a/test/dependency_source/test_poetry.py
+++ b/test/dependency_source/test_poetry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import Callable
+
+import pytest
+from packaging.version import Version
+
+from pip_audit._dependency_source import PoetrySource
+from pip_audit._fix import ResolvedFixVersion
+from pip_audit._service import ResolvedDependency
+
+
+@pytest.fixture
+def lock(tmp_path: Path) -> Callable:
+    def callback(*deps: str) -> Path:
+        metadata = """
+            [tool.poetry]
+            name = "poetry-demo"
+            version = "0.1.0"
+            description = ""
+            authors = ["someone <mail@example.com>"]
+
+            [tool.poetry.dependencies]
+            python = "^3.7"
+        """
+        metadata = dedent(metadata)
+        metadata += "\n".join(deps)
+        (tmp_path / "pyproject.toml").write_text(metadata)
+        cmd = [sys.executable, "-m", "poetry", "lock", "--no-update"]
+        subprocess.run(cmd, cwd=tmp_path).check_returncode()
+        lock_path = tmp_path / "poetry.lock"
+        assert lock_path.exists()
+        return lock_path
+
+    return callback
+
+
+def test_collect_and_fix(lock: Callable) -> None:
+    lock_path: Path = lock("Jinja2 = '2.7.1'")
+    sourcer = PoetrySource(path=lock_path)
+
+    # collect
+    deps = list(sourcer.collect())
+    assert [dep.name for dep in deps] == ["jinja2", "markupsafe"]
+    assert isinstance(deps[0], ResolvedDependency)
+    assert isinstance(deps[1], ResolvedDependency)
+    assert str(deps[0].version) == "2.7.1"
+
+    # unlock the version in metadata
+    meta_path = lock_path.parent / "pyproject.toml"
+    meta_content = meta_path.read_text()
+    meta_content = meta_content.replace("2.7.1", "2.7.*")
+    meta_path.write_text(meta_content)
+
+    # fix
+    sourcer.fix(ResolvedFixVersion(dep=deps[0], version=Version("2.7.3")))
+    content = lock_path.read_text()
+    assert 'version = "2.7.3"' in content
+    assert "2.7.1" not in content

--- a/test/dependency_source/test_poetry.py
+++ b/test/dependency_source/test_poetry.py
@@ -2,33 +2,33 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from packaging.version import Version
 
 from pip_audit._dependency_source import PoetrySource
 from pip_audit._service import ResolvedDependency, SkippedDependency
-from packaging.version import Version
 
 TEST_DATA_PATH = Path(__file__).parent / "data"
 
 
 def test_collect(tmp_path: Path) -> None:
-    lock_content = (TEST_DATA_PATH / 'poetry.lock').read_text()
+    lock_content = (TEST_DATA_PATH / "poetry.lock").read_text()
     lock_path = tmp_path / "poetry.lock"
     lock_path.write_text(lock_content)
     sourcer = PoetrySource(path=lock_path)
     actual = list(sourcer.collect())
     expected = [
-        ResolvedDependency(name='jinja2', version=Version('2.11.3')),
-        ResolvedDependency(name='markupsafe', version=Version('2.1.1')),
+        ResolvedDependency(name="jinja2", version=Version("2.11.3")),
+        ResolvedDependency(name="markupsafe", version=Version("2.1.1")),
     ]
     assert actual == expected
 
 
 def test_invalid_version(tmp_path: Path) -> None:
-    lock_content = (TEST_DATA_PATH / 'poetry.lock').read_text()
-    lock_content = lock_content.replace('2.11.3', 'oh-hi-mark')
+    lock_content = (TEST_DATA_PATH / "poetry.lock").read_text()
+    lock_content = lock_content.replace("2.11.3", "oh-hi-mark")
     lock_path = tmp_path / "poetry.lock"
     lock_path.write_text(lock_content)
     sourcer = PoetrySource(path=lock_path)
     deps = list(sourcer.collect())
-    assert [dep.name for dep in deps] == ['jinja2', 'markupsafe']
+    assert [dep.name for dep in deps] == ["jinja2", "markupsafe"]
     assert isinstance(deps[0], SkippedDependency)


### PR DESCRIPTION
If the project path is specified in CLI, read dependencies from `poetry.lock` file (if available). 

I'm quite happy with `collect`. Since this is a lock file, we can safely skip dependency resolution, as we do for `pip` source. And the format of the file is quite simple, so we don't depend on poetry for reading it. Cool!

Autofix is not supported yet because poetry needs hashes to be updated, see review comments.

I checked the change manually on a few quite big poetry projects, works like a charm.

Close #84 