### PR TITLE
Add VulnerabilityResult.published field

### DIFF
--- a/pip_audit/_service/interface.py
+++ b/pip_audit/_service/interface.py
@@ -6,8 +6,9 @@ of vulnerability information for fully resolved Python packages.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, NewType, Set, Tuple
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from typing import Any, Iterator, NewType
 
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -58,7 +59,7 @@ class ResolvedDependency(Dependency):
     """
 
     version: Version
-    hashes: Dict[str, List[str]] = field(default_factory=dict, hash=False)
+    hashes: dict[str, list[str]] = field(default_factory=dict, hash=False)
 
 
 @dataclass(frozen=True)
@@ -87,14 +88,19 @@ class VulnerabilityResult:
     A human-readable description of the vulnerability.
     """
 
-    fix_versions: List[Version]
+    fix_versions: list[Version]
     """
     A list of versions that can be upgraded to that resolve the vulnerability.
     """
 
-    aliases: Set[str]
+    aliases: set[str]
     """
     A set of aliases (alternative identifiers) for this result.
+    """
+
+    published: datetime | None = None
+    """
+    When the vulnerability was first published.
     """
 
     def alias_of(self, other: VulnerabilityResult) -> bool:
@@ -112,11 +118,10 @@ class VulnerabilityResult:
         """
 
         # Our own ID should never occur in the alias set.
-        return VulnerabilityResult(
-            self.id, self.description, self.fix_versions, self.aliases | other.aliases - {self.id}
-        )
+        aliases = self.aliases | other.aliases - {self.id}
+        return replace(self, aliases=aliases)
 
-    def has_any_id(self, ids: Set[str]) -> bool:
+    def has_any_id(self, ids: set[str]) -> bool:
         """
         Returns whether ids intersects with {id} | aliases.
         """
@@ -131,7 +136,7 @@ class VulnerabilityService(ABC):
     @abstractmethod
     def query(
         self, spec: Dependency
-    ) -> Tuple[Dependency, List[VulnerabilityResult]]:  # pragma: no cover
+    ) -> tuple[Dependency, list[VulnerabilityResult]]:  # pragma: no cover
         """
         Query the `VulnerabilityService` for information about the given `Dependency`,
         returning a list of `VulnerabilityResult`.
@@ -140,7 +145,7 @@ class VulnerabilityService(ABC):
 
     def query_all(
         self, specs: Iterator[Dependency]
-    ) -> Iterator[Tuple[Dependency, List[VulnerabilityResult]]]:
+    ) -> Iterator[tuple[Dependency, list[VulnerabilityResult]]]:
         """
         Query the vulnerability service for information on multiple dependencies.
 
@@ -149,6 +154,12 @@ class VulnerabilityService(ABC):
         """
         for spec in specs:
             yield self.query(spec)
+
+    @staticmethod
+    def _parse_rfs3339(dt: str | None) -> datetime | None:
+        if dt is None:
+            return None
+        return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%SZ")
 
 
 class ServiceError(Exception):

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -1,11 +1,12 @@
 """
 Functionality for using the [OSV](https://osv.dev/) API as a `VulnerabilityService`.
 """
+from __future__ import annotations
 
 import json
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple, cast
+from typing import Any, List, Optional, Tuple, cast
 
 import requests
 from packaging.version import Version
@@ -78,6 +79,7 @@ class OsvService(VulnerabilityService):
         if not response_json:
             return spec, results
 
+        vuln: dict[str, Any]
         for vuln in response_json["vulns"]:
             # Sanity check: only the v1 schema is specified at the moment,
             # and the code below probably won't work with future incompatible
@@ -110,10 +112,10 @@ class OsvService(VulnerabilityService):
             # formatting in the process).
             description = description.replace("\n", " ")
 
-            aliases = set(vuln.get("aliases", []))
-
             # OSV doesn't mandate this field either. There's very little we
             # can do without it, so we skip any results that are missing it.
+            #
+            # TODO(@orsinium): not true anymore, the field is marked as required in API docs.
             affecteds = vuln.get("affected")
             if affecteds is None:
                 logger.warning(f"OSV vuln entry '{id}' is missing 'affected' list")
@@ -141,6 +143,14 @@ class OsvService(VulnerabilityService):
             # The ranges aren't guaranteed to come in chronological order
             fix_versions.sort()
 
-            results.append(VulnerabilityResult(id, description, fix_versions, aliases))
+            results.append(
+                VulnerabilityResult(
+                    id=id,
+                    description=description,
+                    fix_versions=fix_versions,
+                    aliases=set(vuln.get("aliases", [])),
+                    published=self._parse_rfs3339(vuln.get("published")),
+                )
+            )
 
         return spec, results

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -138,6 +138,14 @@ class PyPIService(VulnerabilityService):
             # formatting in the process).
             description = description.replace("\n", " ")
 
-            results.append(VulnerabilityResult(id, description, fix_versions, set(v["aliases"])))
+            results.append(
+                VulnerabilityResult(
+                    id=id,
+                    description=description,
+                    fix_versions=fix_versions,
+                    aliases=set(v["aliases"]),
+                    published=self._parse_rfs3339(v.get("published")),
+                )
+            )
 
         return spec, results

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict, List
 
 import pretend  # type: ignore
@@ -238,6 +239,7 @@ def test_pypi_vuln_description_fallbacks(monkeypatch, cache_dir, summary, detail
                             "summary": summary,
                             "details": details,
                             "fixed_in": ["1.1", "1.4"],
+                            "published": "2019-08-24T14:15:22Z",
                         }
                     ]
                 }
@@ -261,6 +263,7 @@ def test_pypi_vuln_description_fallbacks(monkeypatch, cache_dir, summary, detail
         description=description,
         fix_versions=[Version("1.1"), Version("1.4")],
         aliases={"foo", "bar"},
+        published=datetime(2019, 8, 24, 14, 15, 22),
     )
 
 


### PR DESCRIPTION
Add a new field `published` into `VulnerabilityResult` dataclass. The field holds information about when the vulnerability was published. That information is not used in the CLI or anywhere else yet, only emitted (from both PyPA and OSV sources).

Motivation: in a follow-up PR, I'm going to introduce a new CLI flag for filtering out only advisories published in a specific time window. The motivation for that, in turn, is to be able to have multiple CI jobs in user projects, one that warns about new vulnerabilities and another that fails for all vulnerabilities that weren't resolved in time. But that's another story. For now, just hold that information but don't act on it :)