### PR TITLE
service/osv: remove TODO

### DIFF
--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -114,8 +114,6 @@ class OsvService(VulnerabilityService):
 
             # OSV doesn't mandate this field either. There's very little we
             # can do without it, so we skip any results that are missing it.
-            #
-            # TODO(@orsinium): not true anymore, the field is marked as required in API docs.
             affecteds = vuln.get("affected")
             if affecteds is None:
                 logger.warning(f"OSV vuln entry '{id}' is missing 'affected' list")


### PR DESCRIPTION
Per https://github.com/google/osv.dev/issues/810: this field really is optional, even though the API docs currently being served by osv.dev claim that it isn't.

Signed-off-by: William Woodruff <william@trailofbits.com>