### PR TITLE
pypi_provider: remove an old lint ignore

### DIFF
--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -304,7 +304,7 @@ class PyPIProvider(AbstractProvider):
         return canonicalize_name(requirement_or_candidate.name)
 
     # TODO: Typing. See: https://github.com/sarugaku/resolvelib/issues/104
-    def get_preference(  # type: ignore[override, no-untyped-def]
+    def get_preference(  # type: ignore[no-untyped-def]
         self,
         identifier: Any,
         resolutions: Mapping[Any, Any],


### PR DESCRIPTION
Looks like either mypy got smarter or resolvelib clarified its hints.

Signed-off-by: William Woodruff <william@trailofbits.com>