### PR TITLE
resolvelib: make PEP 503 handling more correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All versions prior to 0.0.9 are untracked.
 
 * Fixed a bug in dependency resolution with third-party indices where
   relative URLs were not resolved correctly
-  ([#411](https://github.com/pypa/pip-audit/pull/411))
+  ([#411](https://github.com/pypa/pip-audit/pull/411),
+  [#412](https://github.com/pypa/pip-audit/pull/412))
 
 ## [2.4.5]
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ optional arguments:
                         base URL of the Python Package Index; this should
                         point to a repository compliant with PEP 503 (the
                         simple repository API) (default:
-                        https://pypi.org/simple)
+                        https://pypi.org/simple/)
   --extra-index-url URL
                         extra URLs of package indexes to use in addition to
                         `--index-url`; should follow the same rules as

--- a/pip_audit/_dependency_source/resolvelib/resolvelib.py
+++ b/pip_audit/_dependency_source/resolvelib/resolvelib.py
@@ -20,7 +20,7 @@ from .pypi_provider import PyPINotFoundError, PyPIProvider
 
 logger = logging.getLogger(__name__)
 
-PYPI_URL = "https://pypi.org/simple"
+PYPI_URL = "https://pypi.org/simple/"
 
 
 Requirement = Union[_Requirement, ParsedRequirement]

--- a/test/dependency_source/resolvelib/test_pypi_provider.py
+++ b/test/dependency_source/resolvelib/test_pypi_provider.py
@@ -83,6 +83,6 @@ def test_get_project_from_index_relative_url():
     assert candidate.filename == Path("Flask-2.0.1-py3-none-any.whl")
     assert candidate.version == Version("2.0.1")
     assert candidate.url == (
-        "https://fake-index.example.com/api/pypi/packages/packages/foo/bar/"
+        "https://fake-index.example.com/api/pypi/pypi-all/packages/packages/foo/bar/"
         "long-hash/Flask-2.0.1-py3-none-any.whl"
     )

--- a/test/dependency_source/resolvelib/test_resolvelib.py
+++ b/test/dependency_source/resolvelib/test_resolvelib.py
@@ -355,7 +355,7 @@ def test_resolvelib_http_notfound(monkeypatch):
         SkippedDependency(
             name="flask",
             skip_reason='Could not find project "flask" on any of the supplied index URLs: '
-            "['https://pypi.org/simple']",
+            "['https://pypi.org/simple/']",
         )
     ]
     assert req in resolved_deps
@@ -365,8 +365,8 @@ def test_resolvelib_http_notfound(monkeypatch):
 def test_resolvelib_multiple_indexes(monkeypatch):
     url1 = "https://index1"
     url2 = "https://index2"
-    package_url1 = f"{url1}/flask"
-    package_url2 = f"{url2}/flask"
+    package_url1 = f"{url1}/flask/"
+    package_url2 = f"{url2}/flask/"
     data1 = (
         '<a href="https://files.pythonhosted.org/packages/d4/6a/'
         "93500f2a7089b4e993fb095215979890b6204a5ba3f6b0f63dc6c3c6c827/Flask-0.5.tar.gz#"
@@ -414,8 +414,8 @@ def test_resolvelib_multiple_indexes(monkeypatch):
 def test_resolvelib_package_missing_on_one_index(monkeypatch):
     url1 = "https://index1"
     url2 = "https://index2"
-    package_url1 = f"{url1}/flask"
-    package_url2 = f"{url2}/flask"
+    package_url1 = f"{url1}/flask/"
+    package_url2 = f"{url2}/flask/"
     data1 = (
         '<a href="https://files.pythonhosted.org/packages/d4/6a/'
         "93500f2a7089b4e993fb095215979890b6204a5ba3f6b0f63dc6c3c6c827/Flask-0.5.tar.gz#"
@@ -485,7 +485,7 @@ def test_resolvelib_no_links(monkeypatch):
         SkippedDependency(
             name="flask",
             skip_reason='Could not find project "flask" on any of the supplied index URLs: '
-            "['https://pypi.org/simple']",
+            "['https://pypi.org/simple/']",
         )
     ]
     assert req in resolved_deps


### PR DESCRIPTION
We now normalize all index URLs to end with a trailing slash, which PEP 503 encourages for maximum compatibility. This also has the added benefit of fixing a `urljoin` bug.