### PR TITLE
pip_audit, test: modernize type hints

### DIFF
--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -1,10 +1,11 @@
 """
 Core auditing APIs.
 """
+from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Iterator, List, Set, Tuple
+from typing import Iterator, Tuple
 
 from pip_audit._dependency_source import DependencySource
 from pip_audit._service import Dependency, VulnerabilityResult, VulnerabilityService
@@ -46,7 +47,7 @@ class Auditor:
 
     def audit(
         self, source: DependencySource
-    ) -> Iterator[Tuple[Dependency, List[VulnerabilityResult]]]:
+    ) -> Iterator[Tuple[Dependency, list[VulnerabilityResult]]]:
         """
         Perform the auditing step, collecting dependencies from `source`.
 
@@ -64,8 +65,8 @@ class Auditor:
             return {}
         else:
             for dep, vulns in self._service.query_all(specs):
-                unique_vulns: List[VulnerabilityResult] = []
-                seen_aliases: Set[str] = set()
+                unique_vulns: list[VulnerabilityResult] = []
+                seen_aliases: set[str] = set()
 
                 # First pass, add all PYSEC vulnerabilities and track their
                 # alias sets.

--- a/pip_audit/_cache.py
+++ b/pip_audit/_cache.py
@@ -2,13 +2,15 @@
 Caching middleware for `pip-audit`.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Optional
+from typing import Any
 
 import pip_api
 import requests
@@ -44,7 +46,7 @@ def _get_pip_cache() -> Path:
     return http_cache_dir
 
 
-def _get_cache_dir(custom_cache_dir: Optional[Path], *, use_pip: bool = True) -> Path:
+def _get_cache_dir(custom_cache_dir: Path | None, *, use_pip: bool = True) -> Path:
     """
     Returns a directory path suitable for HTTP caching.
 
@@ -84,7 +86,7 @@ class _SafeFileCache(FileCache):
         self._logged_warning = False
         super().__init__(directory)
 
-    def get(self, key: str) -> Optional[Any]:
+    def get(self, key: str) -> Any | None:
         try:
             return super().get(key)
         except Exception as e:  # pragma: no cover
@@ -95,7 +97,7 @@ class _SafeFileCache(FileCache):
                 self._logged_warning = True
             return None
 
-    def set(self, key: str, value: bytes, expires: Optional[Any] = None) -> None:
+    def set(self, key: str, value: bytes, expires: Any | None = None) -> None:
         try:
             self._set_impl(key, value)
         except Exception as e:  # pragma: no cover
@@ -140,7 +142,7 @@ class _SafeFileCache(FileCache):
                 self._logged_warning = True
 
 
-def caching_session(cache_dir: Optional[Path], *, use_pip: bool = False) -> CacheControl:
+def caching_session(cache_dir: Path | None, *, use_pip: bool = False) -> CacheControl:
     """
     Return a `requests` style session, with suitable caching middleware.
 

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -2,6 +2,8 @@
 Command-line entrypoints for `pip-audit`.
 """
 
+from __future__ import annotations
+
 import argparse
 import enum
 import logging
@@ -9,7 +11,7 @@ import os
 import sys
 from contextlib import ExitStack
 from pathlib import Path
-from typing import List, NoReturn, Optional, Type, cast
+from typing import NoReturn, Type, cast
 
 from pip_audit import __version__
 from pip_audit._audit import AuditOptions, Auditor
@@ -79,7 +81,7 @@ class VulnerabilityServiceChoice(str, enum.Enum):
     Osv = "osv"
     Pypi = "pypi"
 
-    def to_service(self, timeout: int, cache_dir: Optional[Path]) -> VulnerabilityService:
+    def to_service(self, timeout: int, cache_dir: Path | None) -> VulnerabilityService:
         if self is VulnerabilityServiceChoice.Osv:
             return OsvService(cache_dir, timeout)
         elif self is VulnerabilityServiceChoice.Pypi:
@@ -390,7 +392,7 @@ def audit() -> None:  # pragma: no cover
         source: DependencySource
         index_urls = [args.index_url] + args.extra_index_urls
         if args.requirements is not None:
-            req_files: List[Path] = [Path(req.name) for req in args.requirements]
+            req_files: list[Path] = [Path(req.name) for req in args.requirements]
             # TODO: This is a leaky abstraction; we should construct the ResolveLibResolver
             # within the RequirementSource instead of in-line here.
             source = RequirementSource(

--- a/pip_audit/_dependency_source/interface.py
+++ b/pip_audit/_dependency_source/interface.py
@@ -2,6 +2,7 @@
 Interfaces for interacting with "dependency sources", i.e. sources
 of fully resolved Python dependency trees.
 """
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Iterator, Tuple

--- a/pip_audit/_dependency_source/interface.py
+++ b/pip_audit/_dependency_source/interface.py
@@ -4,7 +4,7 @@ of fully resolved Python dependency trees.
 """
 
 from abc import ABC, abstractmethod
-from typing import Iterator, List, Tuple
+from typing import Iterator, Tuple
 
 from packaging.requirements import Requirement
 
@@ -68,7 +68,7 @@ class DependencyResolver(ABC):
     """
 
     @abstractmethod
-    def resolve(self, req: Requirement) -> List[Dependency]:  # pragma: no cover
+    def resolve(self, req: Requirement) -> list[Dependency]:  # pragma: no cover
         """
         Resolve a single `Requirement` into a list of `Dependency` instances.
         """
@@ -76,7 +76,7 @@ class DependencyResolver(ABC):
 
     def resolve_all(
         self, reqs: Iterator[Requirement]
-    ) -> Iterator[Tuple[Requirement, List[Dependency]]]:
+    ) -> Iterator[Tuple[Requirement, list[Dependency]]]:
         """
         Resolve a collection of `Requirement`s into their respective `Dependency` sets.
 

--- a/pip_audit/_dependency_source/pyproject.py
+++ b/pip_audit/_dependency_source/pyproject.py
@@ -1,12 +1,13 @@
 """
 Collect dependencies from `pyproject.toml` files.
 """
+from __future__ import annotations
 
 import logging
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Iterator, List, Set, cast
+from typing import Iterator, cast
 
 import toml
 from packaging.requirements import Requirement
@@ -54,7 +55,7 @@ class PyProjectSource(DependencySource):
         Raises a `PyProjectSourceError` on any errors.
         """
 
-        collected: Set[Dependency] = set()
+        collected: set[Dependency] = set()
         with self.filename.open("r") as f:
             pyproject_data = toml.load(f)
 
@@ -72,7 +73,7 @@ class PyProjectSource(DependencySource):
                 )
                 return
 
-            reqs: List[Requirement] = [Requirement(dep) for dep in deps]
+            reqs: list[Requirement] = [Requirement(dep) for dep in deps]
             try:
                 for _, deps in self.resolver.resolve_all(iter(reqs)):
                     for dep in deps:
@@ -114,7 +115,7 @@ class PyProjectSource(DependencySource):
                 )
                 return
 
-            reqs: List[Requirement] = [Requirement(dep) for dep in deps]
+            reqs = [Requirement(dep) for dep in deps]
             for i in range(len(reqs)):
                 # When we find a requirement that matches the provided fix version, we need to edit
                 # the requirement's specifier and then write it back to the underlying TOML data.

--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -5,6 +5,8 @@ Closely adapted from `resolvelib`'s examples, which are copyrighted by the `reso
 authors under the ISC license.
 """
 
+from __future__ import annotations
+
 import itertools
 from email.message import EmailMessage, Message
 from email.parser import BytesParser
@@ -13,7 +15,7 @@ from operator import attrgetter
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-from typing import Any, BinaryIO, Iterator, List, Mapping, Optional, Set, Union, cast
+from typing import Any, BinaryIO, Iterator, Mapping, cast
 from urllib.parse import urljoin, urlparse
 from zipfile import ZipFile
 
@@ -50,10 +52,10 @@ class Candidate:
         version: Version,
         *,
         url: str,
-        extras: Set[str],
+        extras: set[str],
         is_wheel: bool,
         session: CacheControl,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         state: AuditState = AuditState(),
     ) -> None:
         """
@@ -70,8 +72,8 @@ class Candidate:
         self._timeout = timeout
         self._state = state
 
-        self._metadata: Optional[Message] = None
-        self._dependencies: Optional[List[Requirement]] = None
+        self._metadata: Message | None = None
+        self._dependencies: list[Requirement] | None = None
 
     def __repr__(self) -> str:  # pragma: no cover
         """
@@ -100,7 +102,7 @@ class Candidate:
         """
         Computes the dependency set for this candidate.
         """
-        deps: List[str] = self.metadata.get_all("Requires-Dist", [])
+        deps: list[str] = self.metadata.get_all("Requires-Dist", [])
         extras = self.extras if self.extras else [""]
 
         for d in deps:
@@ -113,7 +115,7 @@ class Candidate:
                         yield r  # pragma: no cover
 
     @property
-    def dependencies(self) -> List[Requirement]:
+    def dependencies(self) -> list[Requirement]:
         """
         Returns the list of `Requirement`s for this candidate.
         """
@@ -185,11 +187,11 @@ class Candidate:
 
 
 def get_project_from_indexes(
-    index_urls: List[str],
+    index_urls: list[str],
     session: CacheControl,
     project: str,
-    extras: Set[str],
-    timeout: Optional[int],
+    extras: set[str],
+    timeout: int | None,
     state: AuditState,
 ) -> Iterator[Candidate]:
     """Return candidates from all indexes created from the project name and extras."""
@@ -212,8 +214,8 @@ def get_project_from_index(
     index_url: str,
     session: CacheControl,
     project: str,
-    extras: Set[str],
-    timeout: Optional[int],
+    extras: set[str],
+    timeout: int | None,
     state: AuditState,
 ) -> Iterator[Candidate]:
     """Return candidates from an index created from the project name and extras."""
@@ -287,9 +289,9 @@ class PyPIProvider(AbstractProvider):
 
     def __init__(
         self,
-        index_urls: List[str],
-        timeout: Optional[int] = None,
-        cache_dir: Optional[Path] = None,
+        index_urls: list[str],
+        timeout: int | None = None,
+        cache_dir: Path | None = None,
         state: AuditState = AuditState(),
     ):
         """
@@ -313,7 +315,7 @@ class PyPIProvider(AbstractProvider):
         self.session = caching_session(cache_dir, use_pip=True)
         self._state = state
 
-    def identify(self, requirement_or_candidate: Union[Requirement, Candidate]) -> str:
+    def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
         """
         See `resolvelib.providers.AbstractProvider.identify`.
         """
@@ -349,7 +351,7 @@ class PyPIProvider(AbstractProvider):
         bad_versions = {c.version for c in incompatibilities[identifier]}
 
         # Accumulate extras
-        extras: Set[str] = set()
+        extras: set[str] = set()
         for r in requirements:
             extras |= r.extras
 

--- a/pip_audit/_dependency_source/resolvelib/resolvelib.py
+++ b/pip_audit/_dependency_source/resolvelib/resolvelib.py
@@ -2,10 +2,10 @@
 Resolve a list of dependencies via the `resolvelib` API as well as a custom
 `Resolver` that uses PyPI as an information source.
 """
+from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Optional, Union
 
 from packaging.requirements import Requirement as _Requirement
 from pip_api import Requirement as ParsedRequirement
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 PYPI_URL = "https://pypi.org/simple/"
 
 
-Requirement = Union[_Requirement, ParsedRequirement]
+Requirement = _Requirement | ParsedRequirement
 
 
 class ResolveLibResolver(DependencyResolver):
@@ -34,9 +34,9 @@ class ResolveLibResolver(DependencyResolver):
 
     def __init__(
         self,
-        index_urls: List[str] = [PYPI_URL],
-        timeout: Optional[int] = None,
-        cache_dir: Optional[Path] = None,
+        index_urls: list[str] = [PYPI_URL],
+        timeout: int | None = None,
+        cache_dir: Path | None = None,
         skip_editable: bool = False,
         state: AuditState = AuditState(),
     ) -> None:
@@ -56,7 +56,7 @@ class ResolveLibResolver(DependencyResolver):
         self.resolver: Resolver = Resolver(self.provider, self.reporter)
         self._skip_editable = skip_editable
 
-    def resolve(self, req: Requirement) -> List[Dependency]:
+    def resolve(self, req: Requirement) -> list[Dependency]:
         """
         Resolve the given `Requirement` into a `Dependency` list.
         """
@@ -70,7 +70,7 @@ class ResolveLibResolver(DependencyResolver):
                     SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
                 ]
 
-        deps: List[Dependency] = []
+        deps: list[Dependency] = []
         try:
             result = self.resolver.resolve([req])
         except PyPINotFoundError as e:

--- a/pip_audit/_dependency_source/resolvelib/resolvelib.py
+++ b/pip_audit/_dependency_source/resolvelib/resolvelib.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Union
 
 from packaging.requirements import Requirement as _Requirement
 from pip_api import Requirement as ParsedRequirement
@@ -23,7 +24,8 @@ logger = logging.getLogger(__name__)
 PYPI_URL = "https://pypi.org/simple/"
 
 
-Requirement = _Requirement | ParsedRequirement
+# TODO: Replace with _Requirement | ParsedRequirement once our minimum is 3.10.
+Requirement = Union[_Requirement, ParsedRequirement]
 
 
 class ResolveLibResolver(DependencyResolver):

--- a/pip_audit/_fix.py
+++ b/pip_audit/_fix.py
@@ -1,10 +1,11 @@
 """
 Functionality for resolving fixed versions of dependencies.
 """
+from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, cast
+from typing import Any, Iterator, cast
 
 from packaging.version import Version
 
@@ -62,7 +63,7 @@ class SkippedFixVersion(FixVersion):
 
 def resolve_fix_versions(
     service: VulnerabilityService,
-    result: Dict[Dependency, List[VulnerabilityResult]],
+    result: dict[Dependency, list[VulnerabilityResult]],
     state: AuditState = AuditState(),
 ) -> Iterator[FixVersion]:
     """
@@ -87,7 +88,7 @@ def resolve_fix_versions(
 def _resolve_fix_version(
     service: VulnerabilityService,
     dep: ResolvedDependency,
-    vulns: List[VulnerabilityResult],
+    vulns: list[VulnerabilityResult],
     state: AuditState,
 ) -> Version:
     # We need to upgrade to a fix version that satisfies all vulnerability results

--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -2,8 +2,10 @@
 Functionality for formatting vulnerability results as a set of human-readable columns.
 """
 
+from __future__ import annotations
+
 from itertools import zip_longest
-from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
+from typing import Any, Iterable, Tuple, cast
 
 from packaging.version import Version
 
@@ -13,7 +15,7 @@ import pip_audit._service as service
 from .interface import VulnerabilityFormat
 
 
-def tabulate(rows: Iterable[Iterable[Any]]) -> Tuple[List[str], List[int]]:
+def tabulate(rows: Iterable[Iterable[Any]]) -> Tuple[list[str], list[int]]:
     """Return a list of formatted rows and a list of column sizes.
     For example::
     >>> tabulate([['foobar', 2000], [0xdeadbeef]])
@@ -49,8 +51,8 @@ class ColumnsFormat(VulnerabilityFormat):
 
     def format(
         self,
-        result: Dict[service.Dependency, List[service.VulnerabilityResult]],
-        fixes: List[fix.FixVersion],
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
     ) -> str:
         """
         Returns a column formatted string for a given mapping of dependencies to vulnerability
@@ -58,7 +60,7 @@ class ColumnsFormat(VulnerabilityFormat):
 
         See `VulnerabilityFormat.format`.
         """
-        vuln_data: List[List[Any]] = []
+        vuln_data: list[list[Any]] = []
         header = ["Name", "Version", "ID", "Fix Versions"]
         if fixes:
             header.append("Applied Fix")
@@ -89,7 +91,7 @@ class ColumnsFormat(VulnerabilityFormat):
                 columns_string += row
 
         # Now display the skipped dependencies
-        skip_data: List[List[Any]] = []
+        skip_data: list[list[Any]] = []
         skip_header = ["Name", "Skip Reason"]
 
         skip_data.append(skip_header)
@@ -119,8 +121,8 @@ class ColumnsFormat(VulnerabilityFormat):
         self,
         dep: service.ResolvedDependency,
         vuln: service.VulnerabilityResult,
-        applied_fix: Optional[fix.FixVersion],
-    ) -> List[Any]:
+        applied_fix: fix.FixVersion | None,
+    ) -> list[Any]:
         vuln_data = [
             dep.canonical_name,
             dep.version,
@@ -133,10 +135,10 @@ class ColumnsFormat(VulnerabilityFormat):
             vuln_data.append(vuln.description)
         return vuln_data
 
-    def _format_fix_versions(self, fix_versions: List[Version]) -> str:
+    def _format_fix_versions(self, fix_versions: list[Version]) -> str:
         return ",".join([str(version) for version in fix_versions])
 
-    def _format_skipped_dep(self, dep: service.SkippedDependency) -> List[Any]:
+    def _format_skipped_dep(self, dep: service.SkippedDependency) -> list[Any]:
         return [
             dep.canonical_name,
             dep.skip_reason,

--- a/pip_audit/_format/cyclonedx.py
+++ b/pip_audit/_format/cyclonedx.py
@@ -1,10 +1,11 @@
 """
 Functionality for formatting vulnerability results using the CycloneDX SBOM format.
 """
+from __future__ import annotations
 
 import enum
 import logging
-from typing import Dict, List, cast
+from typing import cast
 
 from cyclonedx import output
 from cyclonedx.model.bom import Bom
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class _PipAuditResultParser(BaseParser):
-    def __init__(self, result: Dict[service.Dependency, List[service.VulnerabilityResult]]):
+    def __init__(self, result: dict[service.Dependency, list[service.VulnerabilityResult]]):
         super().__init__()
 
         for (dep, vulns) in result.items():
@@ -77,8 +78,8 @@ class CycloneDxFormat(VulnerabilityFormat):
 
     def format(
         self,
-        result: Dict[service.Dependency, List[service.VulnerabilityResult]],
-        fixes: List[fix.FixVersion],
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
     ) -> str:
         """
         Returns a CycloneDX formatted string for a given mapping of dependencies to vulnerability

--- a/pip_audit/_format/interface.py
+++ b/pip_audit/_format/interface.py
@@ -1,8 +1,9 @@
 """
 Interfaces for formatting vulnerability results into a string representation.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Dict, List
 
 import pip_audit._fix as fix
 import pip_audit._service as service
@@ -29,8 +30,8 @@ class VulnerabilityFormat(ABC):
     @abstractmethod
     def format(
         self,
-        result: Dict[service.Dependency, List[service.VulnerabilityResult]],
-        fixes: List[fix.FixVersion],
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
     ) -> str:  # pragma: no cover
         """
         Convert a mapping of dependencies to vulnerabilities into a string.

--- a/pip_audit/_format/json.py
+++ b/pip_audit/_format/json.py
@@ -1,9 +1,10 @@
 """
 Functionality for formatting vulnerability results as an array of JSON objects.
 """
+from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, cast
+from typing import Any, cast
 
 import pip_audit._fix as fix
 import pip_audit._service as service
@@ -35,8 +36,8 @@ class JsonFormat(VulnerabilityFormat):
 
     def format(
         self,
-        result: Dict[service.Dependency, List[service.VulnerabilityResult]],
-        fixes: List[fix.FixVersion],
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
     ) -> str:
         """
         Returns a JSON formatted string for a given mapping of dependencies to vulnerability
@@ -56,8 +57,8 @@ class JsonFormat(VulnerabilityFormat):
         return json.dumps(output_json)
 
     def _format_dep(
-        self, dep: service.Dependency, vulns: List[service.VulnerabilityResult]
-    ) -> Dict[str, Any]:
+        self, dep: service.Dependency, vulns: list[service.VulnerabilityResult]
+    ) -> dict[str, Any]:
         if dep.is_skipped():
             dep = cast(service.SkippedDependency, dep)
             return {
@@ -72,7 +73,7 @@ class JsonFormat(VulnerabilityFormat):
             "vulns": [self._format_vuln(vuln) for vuln in vulns],
         }
 
-    def _format_vuln(self, vuln: service.VulnerabilityResult) -> Dict[str, Any]:
+    def _format_vuln(self, vuln: service.VulnerabilityResult) -> dict[str, Any]:
         vuln_json = {
             "id": vuln.id,
             "fix_versions": [str(version) for version in vuln.fix_versions],
@@ -81,7 +82,7 @@ class JsonFormat(VulnerabilityFormat):
             vuln_json["description"] = vuln.description
         return vuln_json
 
-    def _format_fix(self, fix_version: fix.FixVersion) -> Dict[str, Any]:
+    def _format_fix(self, fix_version: fix.FixVersion) -> dict[str, Any]:
         if fix_version.is_skipped():
             fix_version = cast(fix.SkippedFixVersion, fix_version)
             return {

--- a/pip_audit/_format/markdown.py
+++ b/pip_audit/_format/markdown.py
@@ -2,8 +2,10 @@
 Functionality for formatting vulnerability results as a Markdown table.
 """
 
+from __future__ import annotations
+
 from textwrap import dedent
-from typing import Dict, List, Optional, cast
+from typing import cast
 
 from packaging.version import Version
 
@@ -37,8 +39,8 @@ class MarkdownFormat(VulnerabilityFormat):
 
     def format(
         self,
-        result: Dict[service.Dependency, List[service.VulnerabilityResult]],
-        fixes: List[fix.FixVersion],
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
     ) -> str:
         """
         Returns a Markdown formatted string representing a set of vulnerability results and applied
@@ -56,8 +58,8 @@ class MarkdownFormat(VulnerabilityFormat):
 
     def _format_vuln_results(
         self,
-        result: Dict[service.Dependency, List[service.VulnerabilityResult]],
-        fixes: List[fix.FixVersion],
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
     ) -> str:
         header = "Name | Version | ID | Fix Versions"
         border = "--- | --- | --- | ---"
@@ -68,7 +70,7 @@ class MarkdownFormat(VulnerabilityFormat):
             header += " | Description"
             border += " | ---"
 
-        vuln_rows: List[str] = []
+        vuln_rows: list[str] = []
         for dep, vulns in result.items():
             if dep.is_skipped():
                 continue
@@ -94,7 +96,7 @@ class MarkdownFormat(VulnerabilityFormat):
         self,
         dep: service.ResolvedDependency,
         vuln: service.VulnerabilityResult,
-        applied_fix: Optional[fix.FixVersion],
+        applied_fix: fix.FixVersion | None,
     ) -> str:
         vuln_text = (
             f"{dep.canonical_name} | {dep.version} | {vuln.id} | "
@@ -106,7 +108,7 @@ class MarkdownFormat(VulnerabilityFormat):
             vuln_text += f" | {vuln.description}"
         return vuln_text
 
-    def _format_fix_versions(self, fix_versions: List[Version]) -> str:
+    def _format_fix_versions(self, fix_versions: list[Version]) -> str:
         return ",".join([str(version) for version in fix_versions])
 
     def _format_applied_fix(self, applied_fix: fix.FixVersion) -> str:
@@ -123,12 +125,12 @@ class MarkdownFormat(VulnerabilityFormat):
         )
 
     def _format_skipped_deps(
-        self, result: Dict[service.Dependency, List[service.VulnerabilityResult]]
+        self, result: dict[service.Dependency, list[service.VulnerabilityResult]]
     ) -> str:
         header = "Name | Skip Reason"
         border = "--- | ---"
 
-        skipped_dep_rows: List[str] = []
+        skipped_dep_rows: list[str] = []
         for dep, _ in result.items():
             if dep.is_skipped():
                 dep = cast(service.SkippedDependency, dep)

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, cast
+from typing import Any, Tuple, cast
 
 import requests
 from packaging.version import Version
@@ -30,7 +30,7 @@ class OsvService(VulnerabilityService):
     package vulnerability information.
     """
 
-    def __init__(self, cache_dir: Optional[Path] = None, timeout: Optional[int] = None):
+    def __init__(self, cache_dir: Path | None = None, timeout: int | None = None):
         """
         Create a new `OsvService`.
 
@@ -43,7 +43,7 @@ class OsvService(VulnerabilityService):
         self.session = caching_session(cache_dir, use_pip=False)
         self.timeout = timeout
 
-    def query(self, spec: Dependency) -> Tuple[Dependency, List[VulnerabilityResult]]:
+    def query(self, spec: Dependency) -> Tuple[Dependency, list[VulnerabilityResult]]:
         """
         Queries OSV for the given `Dependency` specification.
 
@@ -74,7 +74,7 @@ class OsvService(VulnerabilityService):
         # associated vulnerabilities
         #
         # In that case, return an empty list
-        results: List[VulnerabilityResult] = []
+        results: list[VulnerabilityResult] = []
         response_json = response.json()
         if not response_json:
             return spec, results
@@ -119,7 +119,7 @@ class OsvService(VulnerabilityService):
                 logger.warning(f"OSV vuln entry '{id}' is missing 'affected' list")
                 continue
 
-            fix_versions: List[Version] = []
+            fix_versions: list[Version] = []
             for affected in affecteds:
                 pkg = affected["package"]
                 # We only care about PyPI versions

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -2,10 +2,11 @@
 Functionality for using the [PyPI](https://warehouse.pypa.io/api-reference/json.html)
 API as a `VulnerabilityService`.
 """
+from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple, cast
+from typing import Tuple, cast
 
 import requests
 from packaging.version import InvalidVersion, Version
@@ -30,7 +31,7 @@ class PyPIService(VulnerabilityService):
     package vulnerability information.
     """
 
-    def __init__(self, cache_dir: Optional[Path] = None, timeout: Optional[int] = None) -> None:
+    def __init__(self, cache_dir: Path | None = None, timeout: int | None = None) -> None:
         """
         Create a new `PyPIService`.
 
@@ -44,7 +45,7 @@ class PyPIService(VulnerabilityService):
         self.session = caching_session(cache_dir)
         self.timeout = timeout
 
-    def query(self, spec: Dependency) -> Tuple[Dependency, List[VulnerabilityResult]]:
+    def query(self, spec: Dependency) -> Tuple[Dependency, list[VulnerabilityResult]]:
         """
         Queries PyPI for the given `Dependency` specification.
 
@@ -82,7 +83,7 @@ class PyPIService(VulnerabilityService):
             raise ServiceError from http_error
 
         response_json = response.json()
-        results: List[VulnerabilityResult] = []
+        results: list[VulnerabilityResult] = []
 
         # If the dependency has a hash explicitly listed, check it against the PyPI data
         if spec.hashes:

--- a/pip_audit/_state.py
+++ b/pip_audit/_state.py
@@ -2,11 +2,12 @@
 Interfaces for for propagating feedback from the API to provide responsive progress indicators as
 well as a progress spinner implementation for use with CLI applications.
 """
+from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
 from logging.handlers import MemoryHandler
-from typing import Any, List, Sequence
+from typing import Any, Sequence
 
 from rich.console import Console
 
@@ -117,7 +118,7 @@ class AuditSpinner(_StateActor):  # pragma: no cover
         self.log_handler = MemoryHandler(
             0, flushLevel=logging.ERROR, target=None, flushOnClose=False
         )
-        self.prev_handlers: List[logging.Handler] = []
+        self.prev_handlers: list[logging.Handler] = []
 
     def update_state(self, message: str) -> None:
         """

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -2,11 +2,13 @@
 Create virtual environments with a custom set of packages and inspect their dependencies.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import venv
 from types import SimpleNamespace
-from typing import Iterator, List, Optional, Tuple
+from typing import Iterator, Tuple
 
 from packaging.version import Version
 
@@ -37,7 +39,7 @@ class VirtualEnv(venv.EnvBuilder):
     ```
     """
 
-    def __init__(self, install_args: List[str], state: AuditState = AuditState()):
+    def __init__(self, install_args: list[str], state: AuditState = AuditState()):
         """
         Create a new `VirtualEnv`.
 
@@ -52,7 +54,7 @@ class VirtualEnv(venv.EnvBuilder):
         """
         super().__init__(with_pip=True)
         self._install_args = install_args
-        self._packages: Optional[List[Tuple[str, Version]]] = None
+        self._packages: list[Tuple[str, Version]] | None = None
         self._state = state
 
     def post_setup(self, context: SimpleNamespace) -> None:

--- a/test/dependency_source/resolvelib/test_resolvelib.py
+++ b/test/dependency_source/resolvelib/test_resolvelib.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from email.message import EmailMessage
-from typing import List
 
 import pytest
 import requests
@@ -30,7 +31,7 @@ def get_metadata_mock():
     return EmailMessage()
 
 
-def check_deps(resolved_deps: List[ResolvedDependency], expected_deps: List[ResolvedDependency]):
+def check_deps(resolved_deps: list[ResolvedDependency], expected_deps: list[ResolvedDependency]):
     # We don't want to just check that the two lists are equal because:
     # - Some packages install additional dependencies for specific versions of Python. It's only
     #   practical to check that the resolved dependencies contain all the expected ones (but there

--- a/test/dependency_source/test_pip.py
+++ b/test/dependency_source/test_pip.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Dict, List
 
 import pip_api
 import pretend  # type: ignore
@@ -63,8 +64,8 @@ def test_pip_source_invalid_version(monkeypatch):
     # Return a distribution with a version that doesn't conform to PEP 440.
     # We should log a debug message and skip it.
     def mock_installed_distributions(
-        local: bool, paths: List[os.PathLike]
-    ) -> Dict[str, MockDistribution]:
+        local: bool, paths: list[os.PathLike]
+    ) -> dict[str, MockDistribution]:
         return {
             "pytest": MockDistribution("pytest", "0.1"),
             "pip-audit": MockDistribution("pip-audit", "1.0-ubuntu0.21.04.1"),
@@ -100,8 +101,8 @@ def test_pip_source_skips_editable(monkeypatch):
     # Return a distribution with a version that doesn't conform to PEP 440.
     # We should log a debug message and skip it.
     def mock_installed_distributions(
-        local: bool, paths: List[os.PathLike]
-    ) -> Dict[str, MockDistribution]:
+        local: bool, paths: list[os.PathLike]
+    ) -> dict[str, MockDistribution]:
         return {
             "pytest": MockDistribution("pytest", "0.1"),
             "pip-audit": MockDistribution("pip-audit", "2.0.0", True),

--- a/test/dependency_source/test_pyproject.py
+++ b/test/dependency_source/test_pyproject.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List
 
 import pretend  # type: ignore
 import pytest
@@ -97,7 +98,7 @@ dependencies = [
 
 def test_pyproject_source_resolver_error(monkeypatch, req_file):
     class MockResolver(DependencyResolver):
-        def resolve(self, req: Requirement) -> List[Dependency]:
+        def resolve(self, req: Requirement) -> list[Dependency]:
             raise DependencyResolverError
 
     source = _init_pyproject(

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
-from typing import List, Optional
 
 import pip_requirements_parser
 import pretend  # type: ignore
@@ -75,7 +76,7 @@ def test_requirement_source_parse_error(monkeypatch):
 def test_requirement_source_resolver_error(monkeypatch):
     # Pass the requirement source a resolver that automatically raises errors
     class MockResolver(DependencyResolver):
-        def resolve(self, req: Requirement) -> List[Dependency]:
+        def resolve(self, req: Requirement) -> list[Dependency]:
             raise DependencyResolverError
 
     source = requirement.RequirementSource([Path("requirements.txt")], MockResolver())
@@ -161,10 +162,10 @@ def test_requirement_source_non_editable_without_egg_fragment(monkeypatch):
 
 
 def _check_fixes(
-    input_reqs: List[str],
-    expected_reqs: List[str],
-    req_paths: List[Path],
-    fixes: List[ResolvedFixVersion],
+    input_reqs: list[str],
+    expected_reqs: list[str],
+    req_paths: list[Path],
+    fixes: list[ResolvedFixVersion],
 ) -> None:
     # Populate the requirements files
     for (input_req, req_path) in zip(input_reqs, req_paths):
@@ -476,7 +477,7 @@ def test_requirement_source_dep_caching(monkeypatch):
     specs = list(source.collect())
 
     class MockResolver(DependencyResolver):
-        def resolve(self, req: Requirement) -> List[Dependency]:
+        def resolve(self, req: Requirement) -> list[Dependency]:
             raise DependencyResolverError
 
     # Now run collect again and check that dependency resolution doesn't get repeated
@@ -496,7 +497,7 @@ def test_requirement_source_fix_explicit_subdep(monkeypatch, req_file):
 
     # Firstly, get a handle on the `jinja2` dependency. The version cannot be hardcoded since it
     # depends what versions are available on PyPI when dependency resolution runs.
-    jinja_dep: Optional[ResolvedDependency] = None
+    jinja_dep: ResolvedDependency | None = None
     for dep in flask_deps:
         if isinstance(dep, ResolvedDependency) and dep.canonical_name == "jinja2":
             jinja_dep = dep
@@ -524,7 +525,7 @@ def test_requirement_source_fix_explicit_subdep(monkeypatch, req_file):
 def test_requirement_source_fix_explicit_subdep_multiple_reqs(monkeypatch, req_file):
     # Recreate the vulnerable subdependency case.
     flask_deps = ResolveLibResolver().resolve(Requirement("flask==2.0.1"))
-    jinja_dep: Optional[ResolvedDependency] = None
+    jinja_dep: ResolvedDependency | None = None
     for dep in flask_deps:
         if isinstance(dep, ResolvedDependency) and dep.canonical_name == "jinja2":
             jinja_dep = dep
@@ -554,7 +555,7 @@ def test_requirement_source_fix_explicit_subdep_multiple_reqs(monkeypatch, req_f
 def test_requirement_source_fix_explicit_subdep_resolver_error(req_file):
     # Pass the requirement source a resolver that automatically raises errors
     class MockResolver(DependencyResolver):
-        def resolve(self, req: Requirement) -> List[Dependency]:
+        def resolve(self, req: Requirement) -> list[Dependency]:
             raise DependencyResolverError
 
     req_file_name = req_file()
@@ -563,7 +564,7 @@ def test_requirement_source_fix_explicit_subdep_resolver_error(req_file):
 
     # Recreate the vulnerable subdependency case.
     flask_deps = ResolveLibResolver().resolve(Requirement("flask==2.0.1"))
-    jinja_dep: Optional[ResolvedDependency] = None
+    jinja_dep: ResolvedDependency | None = None
     for dep in flask_deps:
         if isinstance(dep, ResolvedDependency) and dep.canonical_name == "jinja2":
             jinja_dep = dep
@@ -601,7 +602,7 @@ def test_requirement_source_fix_explicit_subdep_comment_retension(req_file):
 
     # Recreate the vulnerable subdependency case.
     flask_deps = ResolveLibResolver().resolve(Requirement("flask==2.0.1"))
-    jinja_dep: Optional[ResolvedDependency] = None
+    jinja_dep: ResolvedDependency | None = None
     for dep in flask_deps:
         if isinstance(dep, ResolvedDependency) and dep.canonical_name == "jinja2":
             jinja_dep = dep

--- a/test/format/conftest.py
+++ b/test/format/conftest.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from __future__ import annotations
 
 import pytest
 from packaging.version import Version
@@ -10,7 +10,7 @@ _RESOLVED_DEP_FOO = service.ResolvedDependency(name="foo", version=Version("1.0"
 _RESOLVED_DEP_BAR = service.ResolvedDependency(name="bar", version=Version("0.1"))
 _SKIPPED_DEP = service.SkippedDependency(name="bar", skip_reason="skip-reason")
 
-_TEST_VULN_DATA: Dict[service.Dependency, List[service.VulnerabilityResult]] = {
+_TEST_VULN_DATA: dict[service.Dependency, list[service.VulnerabilityResult]] = {
     _RESOLVED_DEP_FOO: [
         service.VulnerabilityResult(
             id="VULN-0",
@@ -38,7 +38,7 @@ _TEST_VULN_DATA: Dict[service.Dependency, List[service.VulnerabilityResult]] = {
     ],
 }
 
-_TEST_VULN_DATA_SKIPPED_DEP: Dict[service.Dependency, List[service.VulnerabilityResult]] = {
+_TEST_VULN_DATA_SKIPPED_DEP: dict[service.Dependency, list[service.VulnerabilityResult]] = {
     _RESOLVED_DEP_FOO: [
         service.VulnerabilityResult(
             id="VULN-0",
@@ -53,23 +53,23 @@ _TEST_VULN_DATA_SKIPPED_DEP: Dict[service.Dependency, List[service.Vulnerability
     _SKIPPED_DEP: [],
 }
 
-_TEST_NO_VULN_DATA: Dict[service.Dependency, List[service.VulnerabilityResult]] = {
+_TEST_NO_VULN_DATA: dict[service.Dependency, list[service.VulnerabilityResult]] = {
     _RESOLVED_DEP_FOO: [],
     _RESOLVED_DEP_BAR: [],
 }
 
-_TEST_NO_VULN_DATA_SKIPPED_DEP: Dict[service.Dependency, List[service.VulnerabilityResult]] = {
+_TEST_NO_VULN_DATA_SKIPPED_DEP: dict[service.Dependency, list[service.VulnerabilityResult]] = {
     _RESOLVED_DEP_FOO: [],
     _RESOLVED_DEP_BAR: [],
     _SKIPPED_DEP: [],
 }
 
-_TEST_FIX_DATA: List[fix.FixVersion] = [
+_TEST_FIX_DATA: list[fix.FixVersion] = [
     fix.ResolvedFixVersion(dep=_RESOLVED_DEP_FOO, version=Version("1.8")),
     fix.ResolvedFixVersion(dep=_RESOLVED_DEP_BAR, version=Version("0.3")),
 ]
 
-_TEST_SKIPPED_FIX_DATA: List[fix.FixVersion] = [
+_TEST_SKIPPED_FIX_DATA: list[fix.FixVersion] = [
     fix.ResolvedFixVersion(dep=_RESOLVED_DEP_FOO, version=Version("1.8")),
     fix.SkippedFixVersion(dep=_RESOLVED_DEP_BAR, skip_reason="skip-reason"),
 ]

--- a/test/service/test_osv.py
+++ b/test/service/test_osv.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from __future__ import annotations
 
 import pretend  # type: ignore
 import pytest
@@ -23,7 +23,7 @@ def get_mock_session(func):
 def test_osv():
     osv = service.OsvService()
     dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         osv.query_all(iter([dep]))
     )
 
@@ -51,7 +51,7 @@ def test_osv_version_ranges():
     # version
     osv = service.OsvService()
     dep = service.ResolvedDependency("ansible", Version("2.8.0"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         osv.query_all(iter([dep]))
     )
 
@@ -65,11 +65,11 @@ def test_osv_version_ranges():
 @pytest.mark.online
 def test_osv_multiple_pkg():
     osv = service.OsvService()
-    deps: List[service.Dependency] = [
+    deps: list[service.Dependency] = [
         service.ResolvedDependency("jinja2", Version("2.4.1")),
         service.ResolvedDependency("flask", Version("0.5")),
     ]
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         osv.query_all(iter(deps))
     )
 
@@ -84,7 +84,7 @@ def test_osv_multiple_pkg():
 def test_osv_no_vuln():
     osv = service.OsvService()
     dep = service.ResolvedDependency("foo", Version("1.0.0"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         osv.query_all(iter([dep]))
     )
 
@@ -127,7 +127,7 @@ def test_osv_error_response(monkeypatch):
 def test_osv_skipped_dep():
     osv = service.OsvService()
     dep = service.SkippedDependency(name="foo", skip_reason="skip-reason")
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         osv.query_all(iter([dep]))
     )
 

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Dict, List
 
 import pretend  # type: ignore
 import pytest
@@ -24,7 +25,7 @@ def get_mock_session(func):
 def test_pypi(cache_dir):
     pypi = service.PyPIService(cache_dir)
     dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1
@@ -36,11 +37,11 @@ def test_pypi(cache_dir):
 @pytest.mark.online
 def test_pypi_multiple_pkg(cache_dir):
     pypi = service.PyPIService(cache_dir)
-    deps: List[service.Dependency] = [
+    deps: list[service.Dependency] = [
         service.ResolvedDependency("jinja2", Version("2.4.1")),
         service.ResolvedDependency("flask", Version("0.5")),
     ]
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter(deps))
     )
     assert len(results) == 2
@@ -97,7 +98,7 @@ def test_pypi_http_notfound(monkeypatch, cache_dir):
 
     pypi = service.PyPIService(cache_dir)
     dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1
@@ -159,7 +160,7 @@ def test_pypi_mocked_response(monkeypatch, cache_dir):
 
     pypi = service.PyPIService(cache_dir)
     dep = service.ResolvedDependency("foo", Version("1.0"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1
@@ -202,7 +203,7 @@ def test_pypi_vuln_withdrawn(monkeypatch, cache_dir):
 
     pypi = service.PyPIService(cache_dir)
     dep = service.ResolvedDependency("foo", Version("1.0"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1
@@ -252,7 +253,7 @@ def test_pypi_vuln_description_fallbacks(monkeypatch, cache_dir, summary, detail
 
     pypi = service.PyPIService(cache_dir)
     dep = service.ResolvedDependency("foo", Version("1.0"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1
@@ -284,7 +285,7 @@ def test_pypi_no_vuln_key(monkeypatch, cache_dir):
 
     pypi = service.PyPIService(cache_dir)
     dep = service.ResolvedDependency("foo", Version("1.0"))
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1
@@ -325,7 +326,7 @@ def test_pypi_invalid_version(monkeypatch, cache_dir):
 def test_pypi_skipped_dep(cache_dir):
     pypi = service.PyPIService(cache_dir)
     dep = service.SkippedDependency(name="foo", skip_reason="skip-reason")
-    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+    results: dict[service.Dependency, list[service.VulnerabilityResult]] = dict(
         pypi.query_all(iter([dep]))
     )
     assert len(results) == 1

--- a/test/test_fix.py
+++ b/test/test_fix.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from __future__ import annotations
 
 from packaging.version import Version
 
@@ -13,7 +13,7 @@ from pip_audit._service import (
 
 def test_fix(vuln_service):
     dep = ResolvedDependency(name="foo", version=Version("0.5.0"))
-    result: Dict[Dependency, List[VulnerabilityResult]] = {
+    result: dict[Dependency, list[VulnerabilityResult]] = {
         dep: [
             VulnerabilityResult(
                 id="fake-id",
@@ -31,7 +31,7 @@ def test_fix(vuln_service):
 
 def test_fix_skipped_deps(vuln_service):
     dep = SkippedDependency(name="foo", skip_reason="skip-reason")
-    result: Dict[Dependency, List[VulnerabilityResult]] = {
+    result: dict[Dependency, list[VulnerabilityResult]] = {
         dep: [
             VulnerabilityResult(
                 id="fake-id",
@@ -47,14 +47,14 @@ def test_fix_skipped_deps(vuln_service):
 
 def test_fix_no_vulns(vuln_service):
     dep = ResolvedDependency(name="foo", version=Version("0.5.0"))
-    result: Dict[Dependency, List[VulnerabilityResult]] = {dep: list()}
+    result: dict[Dependency, list[VulnerabilityResult]] = {dep: list()}
     fix_versions = list(resolve_fix_versions(vuln_service(), result))
     assert not fix_versions
 
 
 def test_fix_resolution_impossible(vuln_service):
     dep = ResolvedDependency(name="foo", version=Version("0.5.0"))
-    result: Dict[Dependency, List[VulnerabilityResult]] = {
+    result: dict[Dependency, list[VulnerabilityResult]] = {
         dep: [
             VulnerabilityResult(
                 id="fake-id",


### PR DESCRIPTION
Prefer "intrinsic" hints and bar-style unions over `typing.*`

Closes #405.

Signed-off-by: William Woodruff <william@trailofbits.com>