### PR TITLE
service/interface: handle fractional seconds in RFC3339 timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed a timestamp parsing bug that occurred with some vulnerability
+  reports provided by the OSV service
+  ([#416](https://github.com/pypa/pip-audit/issues/416))
+
 ## [2.4.6]
 
 ### Fixed

--- a/pip_audit/_service/interface.py
+++ b/pip_audit/_service/interface.py
@@ -159,7 +159,14 @@ class VulnerabilityService(ABC):
     def _parse_rfc3339(dt: str | None) -> datetime | None:
         if dt is None:
             return None
-        return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%SZ")
+
+        # NOTE: OSV's schema says timestamps are RFC3339 but strptime
+        # has no way to indicate an optional field (like `%f`), so
+        # we have to try-and-retry with the two different expected formats.
+        try:
+            return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%SZ")
 
 
 class ServiceError(Exception):

--- a/pip_audit/_service/interface.py
+++ b/pip_audit/_service/interface.py
@@ -163,6 +163,7 @@ class VulnerabilityService(ABC):
         # NOTE: OSV's schema says timestamps are RFC3339 but strptime
         # has no way to indicate an optional field (like `%f`), so
         # we have to try-and-retry with the two different expected formats.
+        # See: https://github.com/google/osv.dev/issues/857
         try:
             return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S.%fZ")
         except ValueError:

--- a/test/service/test_interface.py
+++ b/test/service/test_interface.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from packaging.version import Version
 
@@ -6,6 +8,7 @@ from pip_audit._service.interface import (
     ResolvedDependency,
     SkippedDependency,
     VulnerabilityResult,
+    VulnerabilityService,
 )
 
 
@@ -73,3 +76,16 @@ def test_vulnerability_result_has_any_id():
     assert result.has_any_id({"ham", "eggs", "BAZ"})
     assert not result.has_any_id({"zilch"})
     assert not result.has_any_id(set())
+
+
+class TestVulnerabilityService:
+    @pytest.mark.parametrize(
+        ["timestamp", "result"],
+        [
+            (None, None),
+            ("2019-08-24T14:15:22Z", datetime.datetime(2019, 8, 24, 14, 15, 22)),
+            ("2022-10-22T00:00:27.668938Z", datetime.datetime(2022, 10, 22, 0, 0, 27, 668938)),
+        ],
+    )
+    def test_parse_rfc3339(self, timestamp, result):
+        assert VulnerabilityService._parse_rfc3339(timestamp) == result


### PR DESCRIPTION
Fixes #416.