### PR TITLE
Set maximum version for packaging, which has removed LegacyVersion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # See: https://github.com/CycloneDX/cyclonedx-python-lib/issues/245
     "cyclonedx-python-lib>=2.0.0,!=2.5.0",
     "html5lib>=1.1",
-    "packaging>=21.0.0",
+    "packaging>=21.0.0,<22.0.0",
     "pip-api>=0.0.28",
     "pip-requirements-parser>=31.2.0",
     "resolvelib>=0.8.0",


### PR DESCRIPTION
pip-audit uses `packaging.version.LegacyVersion` to parse some version numbers, and this is removed in packaging 22.0 (https://github.com/pypa/packaging/pull/407)

Closes #426