### PR TITLE
CLI: write to the output file, not the Path object

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -540,4 +540,4 @@ def audit() -> None:  # pragma: no cover
         # even if nothing other than a dependency summary is present.
         if skip_count > 0 or formatter.is_manifest:
             with _output_io(args.output) as io:
-                print(formatter.format(result, fixes), file=args.output)
+                print(formatter.format(result, fixes), file=io)


### PR DESCRIPTION
I think #432 broke output when ~~there aren't any vulns~~ there are skips (in my case because I'm testing trunk) -- at least here, CI jobs are failing with e.g.:

```
format-audit: commands[1] /home/runner/work/jsonschema/jsonschema/.tox/format-audit/tmp> /home/runner/work/jsonschema/jsonschema/.tox/format-audit/bin/python -m pip_audit
No known vulnerabilities found
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/jsonschema/jsonschema/.tox/format-audit/lib/python3.11/site-packages/pip_audit/__main__.py", line 8, in <module>
    audit()
  File "/home/runner/work/jsonschema/jsonschema/.tox/format-audit/lib/python3.11/site-packages/pip_audit/_cli.py", line 543, in audit
    print(formatter.format(result, fixes), file=args.output)
AttributeError: 'PosixPath' object has no attribute 'write'. Did you mean: 'drive'?
format-audit: exit 1 (2.26 seconds) /home/runner/work/jsonschema/jsonschema/.tox/format-audit/tmp> /home/runner/work/jsonschema/jsonschema/.tox/format-audit/bin/python -m pip_audit pid=1812
  format-audit: FAIL code 1 (21.72=setup[14.21]+cmd[5.25,2.26] seconds)
  evaluation failed :( (21.86 seconds)
Error: Process completed with exit code 1.
```

(from https://github.com/python-jsonschema/jsonschema/actions/runs/3699379673/jobs/6266694002#step:8:70)

This seems to fix things (though I still may be getting a `ResourceWarning` here...)