### PR TITLE
treewide: replace flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 100

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ make lint
 
 * [`black`](https://github.com/psf/black): Code formatting
 * [`isort`](https://github.com/PyCQA/isort): Import sorting, ordering
-* [`flake8`](https://flake8.pycqa.org/en/latest/): PEP-8 linting, style enforcement
+* [`ruff`](https://github.com/charliermarsh/ruff): PEP-8 linting, style enforcement
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ lint: env/pyvenv.cfg
 .PHONY: reformat
 reformat:
 	. env/bin/activate && \
+		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint: env/pyvenv.cfg
 	. env/bin/activate && \
 		black --check $(ALL_PY_SRCS) && \
 		isort --check $(ALL_PY_SRCS) && \
-		flake8 $(ALL_PY_SRCS) && \
+		ruff $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
 		interrogate -c pyproject.toml .
 

--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Iterator, Tuple
+from typing import Iterator
 
 from pip_audit._dependency_source import DependencySource
 from pip_audit._service import Dependency, VulnerabilityResult, VulnerabilityService
@@ -47,7 +47,7 @@ class Auditor:
 
     def audit(
         self, source: DependencySource
-    ) -> Iterator[Tuple[Dependency, list[VulnerabilityResult]]]:
+    ) -> Iterator[tuple[Dependency, list[VulnerabilityResult]]]:
         """
         Perform the auditing step, collecting dependencies from `source`.
 

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -11,7 +11,7 @@ import os
 import sys
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import IO, Iterator, NoReturn, Type, cast
+from typing import IO, Iterator, NoReturn, cast
 
 from pip_audit import __version__
 from pip_audit._audit import AuditOptions, Auditor
@@ -147,7 +147,7 @@ class ProgressSpinnerChoice(str, enum.Enum):
         return self.value
 
 
-def _enum_help(msg: str, e: Type[enum.Enum]) -> str:  # pragma: no cover
+def _enum_help(msg: str, e: type[enum.Enum]) -> str:  # pragma: no cover
     """
     Render a `--help`-style string for the given enumeration.
     """

--- a/pip_audit/_dependency_source/interface.py
+++ b/pip_audit/_dependency_source/interface.py
@@ -5,7 +5,7 @@ of fully resolved Python dependency trees.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterator, Tuple
+from typing import Iterator
 
 from packaging.requirements import Requirement
 
@@ -77,7 +77,7 @@ class DependencyResolver(ABC):
 
     def resolve_all(
         self, reqs: Iterator[Requirement]
-    ) -> Iterator[Tuple[Requirement, list[Dependency]]]:
+    ) -> Iterator[tuple[Requirement, list[Dependency]]]:
         """
         Resolve a collection of `Requirement`s into their respective `Dependency` sets.
 

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -11,7 +11,7 @@ import shutil
 from contextlib import ExitStack
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import IO, Iterator, Tuple, cast
+from typing import IO, Iterator, cast
 
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
@@ -241,7 +241,7 @@ class RequirementSource(DependencySource):
         self,
         reqs: Iterator[InstallRequirement],
         require_hashes: bool = False,
-    ) -> Iterator[Tuple[Requirement, Dependency]]:
+    ) -> Iterator[tuple[Requirement, Dependency]]:
         """
         Collect pre-resolved (pinned) dependencies, optionally enforcing a
         hash requirement policy.
@@ -292,7 +292,7 @@ class RequirementSource(DependencySource):
 
     def _collect_cached_deps(
         self, filename: Path, reqs: list[InstallRequirement]
-    ) -> Iterator[Tuple[Requirement, Dependency]]:
+    ) -> Iterator[tuple[Requirement, Dependency]]:
         """
         Collect resolved dependencies for a given requirements file, retrieving them from the
         dependency cache if possible.

--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -5,7 +5,7 @@ Functionality for formatting vulnerability results as a set of human-readable co
 from __future__ import annotations
 
 from itertools import zip_longest
-from typing import Any, Iterable, Tuple, cast
+from typing import Any, Iterable, cast
 
 from packaging.version import Version
 
@@ -15,7 +15,7 @@ import pip_audit._service as service
 from .interface import VulnerabilityFormat
 
 
-def tabulate(rows: Iterable[Iterable[Any]]) -> Tuple[list[str], list[int]]:
+def tabulate(rows: Iterable[Iterable[Any]]) -> tuple[list[str], list[int]]:
     """Return a list of formatted rows and a list of column sizes.
     For example::
     >>> tabulate([['foobar', 2000], [0xdeadbeef]])

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, Tuple, cast
+from typing import Any, cast
 
 import requests
 from packaging.version import Version
@@ -43,7 +43,7 @@ class OsvService(VulnerabilityService):
         self.session = caching_session(cache_dir, use_pip=False)
         self.timeout = timeout
 
-    def query(self, spec: Dependency) -> Tuple[Dependency, list[VulnerabilityResult]]:
+    def query(self, spec: Dependency) -> tuple[Dependency, list[VulnerabilityResult]]:
         """
         Queries OSV for the given `Dependency` specification.
 

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Tuple, cast
+from typing import cast
 
 import requests
 from packaging.version import InvalidVersion, Version
@@ -45,7 +45,7 @@ class PyPIService(VulnerabilityService):
         self.session = caching_session(cache_dir)
         self.timeout = timeout
 
-    def query(self, spec: Dependency) -> Tuple[Dependency, list[VulnerabilityResult]]:
+    def query(self, spec: Dependency) -> tuple[Dependency, list[VulnerabilityResult]]:
         """
         Queries PyPI for the given `Dependency` specification.
 

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -8,7 +8,7 @@ import json
 import logging
 import venv
 from types import SimpleNamespace
-from typing import Iterator, Tuple
+from typing import Iterator
 
 from packaging.version import Version
 
@@ -54,7 +54,7 @@ class VirtualEnv(venv.EnvBuilder):
         """
         super().__init__(with_pip=True)
         self._install_args = install_args
-        self._packages: list[Tuple[str, Version]] | None = None
+        self._packages: list[tuple[str, Version]] | None = None
         self._state = state
 
     def post_setup(self, context: SimpleNamespace) -> None:
@@ -124,7 +124,7 @@ class VirtualEnv(venv.EnvBuilder):
             self._packages.append((package["name"], Version(package["version"])))
 
     @property
-    def installed_packages(self) -> Iterator[Tuple[str, Version]]:
+    def installed_packages(self) -> Iterator[tuple[str, Version]]:
         """
         A property to inspect the list of packages installed in the virtual environment.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
 ]
 lint = [
     "black>=22.3.0",
-    "flake8",
+    "ruff",
     "interrogate",
     "isort",
     "mypy",
@@ -108,3 +108,6 @@ warn_unused_ignores = true
 [tool.bump]
 input = "pip_audit/__init__.py"
 reset = true
+
+[tool.ruff]
+line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,5 @@ reset = true
 
 [tool.ruff]
 line-length = 100
+select = ["E", "F", "W", "UP"]
+target-version = "py37"

--- a/test/dependency_source/test_pyproject.py
+++ b/test/dependency_source/test_pyproject.py
@@ -26,7 +26,7 @@ def _init_pyproject(filename: Path, contents: str) -> pyproject.PyProjectSource:
 
 
 def _check_file(filename: Path, expected_contents: dict) -> None:
-    with open(filename, mode="r") as f:
+    with open(filename) as f:
         assert toml.load(f) == expected_contents
 
 

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -178,7 +178,7 @@ def _check_fixes(
 
     # Check the requirements files
     for (expected_req, req_path) in zip(expected_reqs, req_paths):
-        with open(req_path, "r") as f:
+        with open(req_path) as f:
             # NOTE: We don't make any guarantees about non-semantic whitespace
             # preservation, hence the strip.
             assert expected_req == f.read().strip()
@@ -302,7 +302,7 @@ def test_requirement_source_fix_parse_failure(monkeypatch, req_file):
     # Check that the requirements files remain unchanged
     # If we encounter a failure while applying a fix, the fix should be rolled back from all files
     for (expected_req, req_path) in zip(input_reqs, req_paths):
-        with open(req_path, "r") as f:
+        with open(req_path) as f:
             assert expected_req == f.read().strip()
 
 
@@ -341,7 +341,7 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
     # in the process of writing it out and didn't flush.
     expected_reqs = ["flask==1.0", "flask==0.5\nrequests==2.0\nflask==0.3"]
     for (expected_req, req_path) in zip(expected_reqs, req_paths):
-        with open(req_path, "r") as f:
+        with open(req_path) as f:
             assert expected_req == f.read().strip()
 
 


### PR DESCRIPTION
Similar to https://github.com/sigstore/sigstore-python/pull/353.

Signed-off-by: William Woodruff <william@trailofbits.com>