### PR TITLE
pip_audit, test: handle invalid requires-python specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed a crash triggered when a package specifies an invalid version
+  specifier for its `requires-python` version
+  ([#447](https://github.com/pypa/pip-audit/pull/447))
+
 ## [2.4.10]
 
 ### Fixed


### PR DESCRIPTION
We follow `pip`'s lead here and ignore these entirely, treating them as if they don't exist (while also warning the user).

Fixes #445.

See: https://github.com/pypa/packaging/issues/645

Signed-off-by: William Woodruff <william@trailofbits.com>