### PR TITLE
pip_audit, test: `ruff` fixes

### DIFF
--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -75,7 +75,7 @@ class ColumnsFormat(VulnerabilityFormat):
             for vuln in vulns:
                 vuln_data.append(self._format_vuln(dep, vuln, applied_fix))
 
-        columns_string = str()
+        columns_string = ""
 
         # If it's just a header, don't bother adding it to the output
         if len(vuln_data) > 1:

--- a/pip_audit/_format/markdown.py
+++ b/pip_audit/_format/markdown.py
@@ -80,7 +80,7 @@ class MarkdownFormat(VulnerabilityFormat):
                 vuln_rows.append(self._format_vuln(dep, vuln, applied_fix))
 
         if not vuln_rows:
-            return str()
+            return ""
 
         return (
             dedent(
@@ -137,7 +137,7 @@ class MarkdownFormat(VulnerabilityFormat):
                 skipped_dep_rows.append(self._format_skipped_dep(dep))
 
         if not skipped_dep_rows:
-            return str()
+            return ""
 
         return (
             dedent(

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -37,7 +37,7 @@ def run(args: Sequence[str], *, state: AuditState = AuditState()) -> str:
     pretty_args = " ".join([os.path.basename(args[0]), *args[1:]])
 
     terminated = False
-    stdout = bytes()
+    stdout = b""
 
     # NOTE: We use `poll()` to control this loop instead of the `read()` call
     # to prevent deadlocks. Similarly, `read(size)` will return an empty bytes

--- a/test/dependency_source/resolvelib/test_resolvelib.py
+++ b/test/dependency_source/resolvelib/test_resolvelib.py
@@ -470,7 +470,7 @@ def test_resolvelib_package_missing_on_one_index(monkeypatch):
             return get_package_mock(data1)
         else:
             assert url == package_url2
-            pkg = get_package_mock(str())
+            pkg = get_package_mock("")
             pkg.status_code = 404
             return pkg
 
@@ -504,7 +504,7 @@ def test_resolvelib_skip_editable():
 
 def test_resolvelib_no_links(monkeypatch):
     # Simulate the project page containing no versions
-    data = str()
+    data = ""
 
     monkeypatch.setattr(
         pypi_provider.Candidate, "_get_metadata_for_wheel", lambda _: get_metadata_mock()

--- a/test/dependency_source/test_pip.py
+++ b/test/dependency_source/test_pip.py
@@ -147,7 +147,7 @@ def test_pip_source_fix_failure(monkeypatch):
 
     def run_mock(args, **kwargs):
         assert " ".join(args) == f"{sys.executable} -m pip install pip-api==1.5"
-        raise subprocess.CalledProcessError(-1, str())
+        raise subprocess.CalledProcessError(-1, "")
 
     monkeypatch.setattr(subprocess, "run", run_mock)
 

--- a/test/format/test_columns.py
+++ b/test/format/test_columns.py
@@ -42,7 +42,7 @@ bar  skip-reason"""
 
 def test_columns_no_vuln_data(no_vuln_data):
     columns_format = format.ColumnsFormat(False)
-    expected_columns = str()
+    expected_columns = ""
     assert columns_format.format(no_vuln_data, list()) == expected_columns
 
 

--- a/test/format/test_markdown.py
+++ b/test/format/test_markdown.py
@@ -46,7 +46,7 @@ bar | skip-reason"""
 
 def test_markdown_no_vuln_data(no_vuln_data):
     markdown_format = format.MarkdownFormat(False)
-    expected_markdown = str()
+    expected_markdown = ""
     assert markdown_format.format(no_vuln_data, list()) == expected_markdown
 
 


### PR DESCRIPTION
`ruff` prefers this style, apparently.