### PR TITLE
Include setuptools in upgrade set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed `pip-audit`'s virtual environment creation and upgrade behavior,
+  preventing spurious vulnerability reports
+  ([#454](https://github.com/pypa/pip-audit/pull/454))
+
 ## [2.4.11]
 
 ### Fixed

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -86,6 +86,7 @@ class VirtualEnv(venv.EnvBuilder):
             "--upgrade",
             "pip",
             "wheel",
+            "setuptools",
         ]
         try:
             run(pip_upgrade_cmd, state=self._state)

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -78,6 +78,8 @@ class VirtualEnv(venv.EnvBuilder):
 
         # Firstly, upgrade our `pip` versions since `ensurepip` can leave us with an old version
         # and install `wheel` in case our package dependencies are offered as wheels
+        # TODO: This is probably replaceable with the `upgrade_deps` option on `EnvBuilder`
+        # itself, starting with Python 3.9.
         pip_upgrade_cmd = [
             context.env_exe,
             "-m",


### PR DESCRIPTION
This looks like an oversight on our part: we should keep setuptools upgraded along with `pip` and `wheel`, since the default environment one can be pretty old.