### PR TITLE
pip_audit: `ruff` fixes

### DIFF
--- a/pip_audit/_cache.py
+++ b/pip_audit/_cache.py
@@ -113,7 +113,7 @@ class _SafeFileCache(FileCache):
         # Make sure the directory exists
         try:
             os.makedirs(os.path.dirname(name), self.dirmode)
-        except (IOError, OSError):  # pragma: no cover
+        except OSError:  # pragma: no cover
             pass
 
         # We don't want to use lock files since `pip` isn't going to recognise those. We should


### PR DESCRIPTION
I initially thought this was a false positive, but it looks like CPython's documentation on `IOError` is slightly stale.

xref https://github.com/charliermarsh/ruff/issues/1568