### PR TITLE
requirement: Fix `--skip-editable` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All versions prior to 0.0.9 are untracked.
 * Fixed an issue where hash checking would fail when using third-party indices
   ([#462](https://github.com/pypa/pip-audit/pull/462))
 
+* Fixed the behavior of the `--skip-editable` flag, which had regressed
+  with an internal API change
+  ([#499](https://github.com/pypa/pip-audit/pull/499))
+
 ## [2.4.14]
 
 ### Fixed

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -416,11 +416,10 @@ def audit() -> None:  # pragma: no cover
             # within the RequirementSource instead of in-line here.
             source = RequirementSource(
                 req_files,
-                ResolveLibResolver(
-                    index_urls, args.timeout, args.cache_dir, args.skip_editable, state
-                ),
+                ResolveLibResolver(index_urls, args.timeout, args.cache_dir, state),
                 require_hashes=args.require_hashes,
                 no_deps=args.no_deps,
+                skip_editable=args.skip_editable,
                 state=state,
             )
         elif args.project_path is not None:
@@ -430,9 +429,7 @@ def audit() -> None:  # pragma: no cover
             # Determine which kind of project file exists in the project path
             source = _dep_source_from_project_path(
                 args.project_path,
-                ResolveLibResolver(
-                    index_urls, args.timeout, args.cache_dir, args.skip_editable, state
-                ),
+                ResolveLibResolver(index_urls, args.timeout, args.cache_dir, state),
                 state,
             )
         else:

--- a/test/dependency_source/resolvelib/test_resolvelib.py
+++ b/test/dependency_source/resolvelib/test_resolvelib.py
@@ -7,7 +7,6 @@ import pytest
 import requests
 from packaging.requirements import Requirement
 from packaging.version import Version
-from pip_api import Requirement as ParsedRequirement
 from requests.exceptions import HTTPError
 
 from pip_audit._dependency_source import RequirementHashes, resolvelib
@@ -497,15 +496,6 @@ def test_resolvelib_package_missing_on_one_index(monkeypatch):
     resolved_deps = dict(resolver.resolve_all(iter([req]), RequirementHashes()))
     assert req in resolved_deps
     assert resolved_deps[req] == [ResolvedDependency("flask", Version("0.5"))]
-
-
-def test_resolvelib_skip_editable():
-    resolver = resolvelib.ResolveLibResolver(skip_editable=True)
-    req = ParsedRequirement("foo==1.0.0", editable=True, filename="stub", lineno=1)
-
-    deps = resolver.resolve(req, RequirementHashes())  # type: ignore
-    assert len(deps) == 1
-    assert deps[0] == SkippedDependency(name="foo", skip_reason="requirement marked as editable")
 
 
 def test_resolvelib_no_links(monkeypatch):

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -169,6 +169,20 @@ def test_requirement_source_non_editable_without_egg_fragment(monkeypatch):
     )
 
 
+@pytest.mark.online
+def test_requirement_source_editable_skip(monkeypatch):
+    source = requirement.RequirementSource(
+        [Path("requirements1.txt")], ResolveLibResolver(), skip_editable=True
+    )
+
+    monkeypatch.setattr(
+        pip_requirements_parser, "get_file_content", lambda _: "-e file:flask.py#egg=flask==2.0.1"
+    )
+
+    specs = list(source.collect())
+    assert SkippedDependency(name="flask", skip_reason="requirement marked as editable") in specs
+
+
 def _check_fixes(
     input_reqs: list[str],
     expected_reqs: list[str],


### PR DESCRIPTION
This has been broken since we moved away from `pip-api` to `pip-requirements-parser` for parsing. Unfortunately, unit tests didn't pick up on this since we were passing the `pip-api` object directly into the resolver.