### PR TITLE
pyproject.toml: Don't check for line-length with `ruff` since we're reformatting with `black`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat:
 	. $(VENV_BIN)/activate && \
+		black $(ALL_PY_SRCS) && \
 		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat:
 	. $(VENV_BIN)/activate && \
-		black $(ALL_PY_SRCS) && \
 		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ input = "pip_audit/__init__.py"
 reset = true
 
 [tool.ruff]
-line-length = 100
+# Never enforce `E501` (line length violations).
+ignore = ["E501"]
 select = ["E", "F", "W", "UP"]
 target-version = "py37"


### PR DESCRIPTION
I've found this to be mildly annoying when running `make reformat`. Basically, `ruff` complains about lines being too long and I have to break lines manually to get past `ruff` and let `black` run.

`black` also needs to run after `ruff` since `ruff` could make edits that are incompatible with `black` so if we don't run `black` twice, we'd get into a situation where we'd need to run `make reformat` twice to make sure that there aren't any fixes needed.