### PR TITLE
pip_audit: handle subprocess streams more cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All versions prior to 0.0.9 are untracked.
   has an invalid (non-PEP 440) requirements specifier
   ([#507](https://github.com/pypa/pip-audit/pull/507))
 
+* `pip-audit`'s handling of dependency resolution has been significantly
+  refactored and simplified ([#523](https://github.com/pypa/pip-audit/pull/523))
+
+### Fixed
+
+* Fixed a potential crash on invalid unicode in subprocess streams
+  ([#536](https://github.com/pypa/pip-audit/pull/536))
+
 ## [2.4.15]
 
 **YANKED**

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -17,6 +17,9 @@ class CalledProcessError(Exception):
     """
 
     def __init__(self, msg: str, *, stderr: str) -> None:
+        """
+        Create a new `CalledProcessError`.
+        """
         super().__init__(msg)
         self.stderr = stderr
 

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -16,6 +16,10 @@ class CalledProcessError(Exception):
     Raised if the underlying subprocess created by `run` exits with a nonzero code.
     """
 
+    def __init__(self, msg: str, *, stderr: str) -> None:
+        super().__init__(msg)
+        self.stderr = stderr
+
 
 def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = AuditState()) -> str:
     """
@@ -29,7 +33,7 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
 
     # Run the process with unbuffered I/O, to make the poll-and-read loop below
     # more responsive.
-    process = Popen(args, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    process = Popen(args, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     # NOTE(ww): We frequently run commands inside of ephemeral virtual environments,
     # which have long absolute paths on some platforms. These make for confusing
@@ -38,6 +42,7 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
 
     terminated = False
     stdout = b""
+    stderr = b""
 
     # NOTE: We use `poll()` to control this loop instead of the `read()` call
     # to prevent deadlocks. Similarly, `read(size)` will return an empty bytes
@@ -45,9 +50,15 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
     while not terminated:
         terminated = process.poll() is not None
         stdout += process.stdout.read(4096)  # type: ignore
-        state.update_state(f"Running {pretty_args}", stdout.decode() if log_stdout else None)
+        stderr += process.stderr.read(4096)  # type: ignore
+        state.update_state(
+            f"Running {pretty_args}", stdout.decode(errors="replace") if log_stdout else None
+        )
 
     if process.returncode != 0:
-        raise CalledProcessError(f"{pretty_args} exited with {process.returncode}")
+        raise CalledProcessError(
+            f"{pretty_args} exited with {process.returncode}",
+            stderr=stderr.decode(errors="replace"),
+        )
 
     return stdout.decode("utf-8")

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -52,6 +52,7 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
     # once `stdout` hits EOF, so we don't have to worry about that blocking.
     while not terminated:
         terminated = process.poll() is not None
+        # NOTE(ww): Buffer size chosen arbitrarily here and below.
         stdout += process.stdout.read(4096)  # type: ignore
         stderr += process.stderr.read(4096)  # type: ignore
         state.update_state(

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -123,6 +123,8 @@ class VirtualEnv(venv.EnvBuilder):
             try:
                 run(package_install_cmd, log_stdout=True, state=self._state)
             except CalledProcessError as cpe:
+                # TODO: Propagate the subprocess's error output better here.
+                logger.error(f"internal pip failure: {cpe.stderr}")
                 raise VirtualEnvError(f"Failed to install packages: {package_install_cmd}") from cpe
 
             self._state.update_state("Processing package list from isolated environment")

--- a/test/test_virtual_env.py
+++ b/test/test_virtual_env.py
@@ -29,7 +29,7 @@ def test_virtual_env_failed_package_installation(monkeypatch):
 
     def run_mock(args, **kwargs):
         if "flask==2.0.1" in args:
-            raise _subprocess.CalledProcessError("barf")
+            raise _subprocess.CalledProcessError("barf", stderr="")
         # If it's not the package installation command, then call the original run
         return original_run(args, **kwargs)
 
@@ -48,7 +48,7 @@ def test_virtual_env_failed_pip_upgrade(monkeypatch):
         # We have to be a bit more specific than usual here because the `EnvBuilder` invokes
         # `ensurepip` with similar looking arguments and we DON'T want to mock that call.
         if set(["install", "--upgrade", "pip"]).issubset(set(args)):
-            raise _subprocess.CalledProcessError("barf")
+            raise _subprocess.CalledProcessError("barf", stderr="")
         # If it's not a call to upgrade pip, then call the original run
         return original_run(args, **kwargs)
 


### PR DESCRIPTION
This is just a followup to #523, with a few resiliency improvements:

* We collect the `pip` subprocess's `stderr` and display it with an error message on failure;
* We handle invalid UTF-8 more gracefully in both `stdout` and `stderr`, as there's no guarantee that `pip install ...` only prints valid unicode.