### PR TITLE
Prep 2.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.4.15
+    rev: v2.5.0
     hooks:
       - id: pip-audit
   - repo: https://github.com/rhysd/actionlint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+## [2.5.0]
+
 ### Changed
 
 * Improved error messaging when a requirements input or indirect dependency
@@ -465,7 +467,8 @@ All versions prior to 0.0.9 are untracked.
   dependency errors ([#146](https://github.com/pypa/pip-audit/pull/146))
 
 <!-- Release URLs -->
-[Unreleased]: https://github.com/pypa/pip-audit/compare/v2.4.15...HEAD
+[Unreleased]: https://github.com/pypa/pip-audit/compare/v2.5.0...HEAD
+[2.4.15]: https://github.com/pypa/pip-audit/compare/v2.4.15...v2.5.0
 [2.4.15]: https://github.com/pypa/pip-audit/compare/v2.4.14...v2.4.15
 [2.4.14]: https://github.com/pypa/pip-audit/compare/v2.4.13...v2.4.14
 [2.4.13]: https://github.com/pypa/pip-audit/compare/v2.4.12...v2.4.13

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For example, using `pip-audit` via `pre-commit` to audit a requirements file:
 
 ```yaml
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.4.15
+    rev: v2.5.0
     hooks:
       -   id: pip-audit
           args: ["-r", "requirements.txt"]

--- a/pip_audit/__init__.py
+++ b/pip_audit/__init__.py
@@ -2,4 +2,4 @@
 The `pip_audit` APIs.
 """
 
-__version__ = "2.4.15"
+__version__ = "2.5.0"


### PR DESCRIPTION
This preps 2.5.0 for release.

Minor version bump is technically not required, but commemorates/marks significant internal changes here (e.g. the refactoring to use `pip --report`).