### PR TITLE
workflows/release: configure environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   pypi:
     name: upload release to PyPI
     runs-on: ubuntu-latest
+    environment: release
 
     permissions:
       # Used to authenticate to PyPI via OIDC.


### PR DESCRIPTION
This runs the `release.yml` workflow in the `release` environment, which has been configured to require manual approval from a maintainer or admin of the repo.