### PR TITLE
pyproject: constrain cyclonedx to ~2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
     "CacheControl[filecache]>=0.12.10",
     # NOTE(ww): Release 2.5.0 is broken, subsequent 2.5.x releases fix it.
     # See: https://github.com/CycloneDX/cyclonedx-python-lib/issues/245
-    "cyclonedx-python-lib>=2.0.0,!=2.5.0",
+    "cyclonedx-python-lib~=2,!=2.5.0",
     "html5lib>=1.1",
-    "packaging>=23.0.0",  # https://github.com/pypa/pip-audit/issues/464
+    "packaging>=23.0.0",               # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",
     "pip-requirements-parser>=32.0.0",
     "rich>=12.4",
@@ -41,12 +41,7 @@ dependencies = [
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-test = [
-    "coverage[toml]",
-    "pretend",
-    "pytest",
-    "pytest-cov",
-]
+test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
 lint = [
     "black>=22.3.0",
     # NOTE(ww): ruff is under active development, so we pin conservatively here
@@ -59,14 +54,8 @@ lint = [
     "types-requests",
     "types-toml",
 ]
-doc = [
-    "pdoc",
-]
-dev = [
-    "build",
-    "bump>=1.3.2",
-    "pip-audit[doc,test,lint]",
-]
+doc = ["pdoc"]
+dev = ["build", "bump>=1.3.2", "pip-audit[doc,test,lint]"]
 
 [project.scripts]
 pip-audit = "pip_audit._cli:audit"


### PR DESCRIPTION
`cyclonedx-python-lib` suddenly released a new major, so this was no longer constrained correctly.

Reflow as well.

This should fix the broken CI.