### PR TITLE
_subprocess: Fix `pip install` log window not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ All versions prior to 0.0.9 are untracked.
 * Fixed a crash on Windows caused by multiple open file handles to
   input requirements ([#551](https://github.com/pypa/pip-audit/pull/551))
 
+* Fixed an issue where the log window that we use to display `pip-audit`'s
+  dependency resolution progress was not showing anything
+  ([#567](https://github.com/pypa/pip-audit/pull/567))
+
 ## [2.5.0]
 
 ### Changed

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -57,6 +57,9 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
             f"Running {pretty_args}", stdout.decode(errors="replace") if log_stdout else None
         )
 
+    # NOTE(alex): For reasons I'm unsure about, reading the stderr stream in
+    # real time seems to interfere with stdout and cause us to read nothing.
+    # Let's wait until the process is terminated before reading stderr.
     stderr = process.stderr.read()  # type: ignore
     if process.returncode != 0:
         raise CalledProcessError(

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -45,7 +45,6 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
 
     terminated = False
     stdout = b""
-    stderr = b""
 
     # NOTE: We use `poll()` to control this loop instead of the `read()` call
     # to prevent deadlocks. Similarly, `read(size)` will return an empty bytes
@@ -54,11 +53,11 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
         terminated = process.poll() is not None
         # NOTE(ww): Buffer size chosen arbitrarily here and below.
         stdout += process.stdout.read(4096)  # type: ignore
-        stderr += process.stderr.read(4096)  # type: ignore
         state.update_state(
             f"Running {pretty_args}", stdout.decode(errors="replace") if log_stdout else None
         )
 
+    stderr = process.stderr.read()  # type: ignore
     if process.returncode != 0:
         raise CalledProcessError(
             f"{pretty_args} exited with {process.returncode}",


### PR DESCRIPTION
Related to https://github.com/pypa/pip-audit/pull/536. I noticed this when debugging something else. For some reason, when we read `stderr` in the polling loop, it causes us to read nothing for `stdout`. There's no reason that we need to read `stderr` in the loop since it's not getting dumped into the log window so I just moved this code out of the loop.