### PR TITLE
_subprocess: perform invalid UTF-8 substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All versions prior to 0.0.9 are untracked.
   behaviour when using hashed requirements or the `--no-deps` flag
   ([#540](https://github.com/pypa/pip-audit/pull/540))
 
+### Fixed
+
+* Fixed a crash caused by invalid UTF-8 sequences in subprocess outputs
+  ([#572](https://github.com/pypa/pip-audit/pull/572))
+
 ## [2.5.2]
 
 ### Fixed

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -65,4 +65,4 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
             stderr=stderr.decode(errors="replace"),
         )
 
-    return stdout.decode("utf-8")
+    return stdout.decode("utf-8", errors="replace")


### PR DESCRIPTION
Fixes #569.

Fixes #573.