### PR TITLE
pyproject: add, pin requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All versions prior to 0.0.9 are untracked.
 * Fixed a crash caused by invalid UTF-8 sequences in subprocess outputs
   ([#572](https://github.com/pypa/pip-audit/pull/572))
 
+* Fixed a crash caused by incompatible dependency changes
+  ([#605](https://github.com/pypa/pip-audit/pull/605))
+
 ## [2.5.2]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "packaging>=23.0.0",                     # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",
     "pip-requirements-parser>=32.0.0",
+    "requests==2.29.*",
     "rich>=12.4",
     "toml>=0.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "packaging>=23.0.0",                     # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",
     "pip-requirements-parser>=32.0.0",
-    # NOTE(ww): requests 2.30.0 and higher are incompatible with CacheControl;
+    # NOTE(ww): urllib3 2.0 and higher are incompatible with CacheControl;
+    # we prevent its use by using a version of requests that uses urllib3 < 2.0.
     # See: https://github.com/psf/requests/issues/6437
     "requests<2.30",
     "rich>=12.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pip-requirements-parser>=32.0.0",
     # NOTE(ww): requests 2.30.0 and higher are incompatible with CacheControl;
     # See: https://github.com/psf/requests/issues/6437
-    "requests==2.29.*",
+    "requests<2.30",
     "rich>=12.4",
     "toml>=0.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "packaging>=23.0.0",                     # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",
     "pip-requirements-parser>=32.0.0",
+    # NOTE(ww): requests 2.30.0 and higher are incompatible with CacheControl;
+    # See: https://github.com/psf/requests/issues/6437
     "requests==2.29.*",
     "rich>=12.4",
     "toml>=0.10",


### PR DESCRIPTION
Looks like we were implicitly depending on this before, despite explicitly importing it, which is bad!

This adds a `2.29.*` constraint on our `requests` dep, which should block off a regression in `CacheControl` due to underlying changes in `urllib3` for the time being.

xrefs:

* https://github.com/psf/requests/issues/6437
* https://github.com/ionrock/cachecontrol/issues/292