### PR TITLE
bump minimum Python to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -31,7 +31,7 @@ jobs:
         # in this check, since Python can change the `--help` rendering in
         # `argparse` between major versions.
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: ">= 3.7"
+        python-version: ">= 3.8"
         cache: "pip"
         cache-dependency-path: pyproject.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* `pip-audit`'s minimum Python version is now 3.8.
+
 ## [2.6.1]
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ as well as performing common development tasks.
 
 ## Requirements
 
-`pip-audit`'s only development environment requirement *should* be Python 3.7
+`pip-audit`'s only development environment requirement *should* be Python 3.8
 or newer. Development and testing is actively performed on macOS and Linux,
 but Windows and other supported platforms that are supported by Python
 should also work.
@@ -79,7 +79,7 @@ including code coverage with [`coverage.py`](https://coverage.readthedocs.io/).
 
 ### Documentation
 
-If you're running Python 3.7 or newer, you can run the documentation build locally:
+You can run the documentation build locally:
 
 ```bash
 make doc

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ with support from Google. This is not an official Google or Trail of Bits produc
 
 ## Installation
 
-`pip-audit` requires Python 3.7 or newer, and can be installed directly via `pip`:
+`pip-audit` requires Python 3.8 or newer, and can be installed directly via `pip`:
 
 ```bash
 python -m pip install pip-audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
     "rich>=12.4",
     "toml>=0.10",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
@@ -97,5 +96,4 @@ reset = true
 # Never enforce `E501` (line length violations).
 ignore = ["E501"]
 select = ["E", "F", "I", "W", "UP"]
-target-version = "py37"
 line-length = 100


### PR DESCRIPTION
3.7 is EOL, and will soon begin dragging some of our support tooling. 