### PR TITLE
Allow build with cyclonedx-python-lib 6.0.0+

### DIFF
--- a/pip_audit/_format/cyclonedx.py
+++ b/pip_audit/_format/cyclonedx.py
@@ -90,7 +90,7 @@ class CycloneDxFormat(VulnerabilityFormat):
             logger.warning("--fix output is unsupported by CycloneDX formats")
 
         bom = _pip_audit_result_to_bom(result)
-        formatter = output.get_instance(
+        formatter = output.make_outputter(
             bom=bom,
             output_format=self._inner_format.value,
             schema_version=output.SchemaVersion.V1_4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "CacheControl[filecache] >= 0.13.0",
-    "cyclonedx-python-lib >= 4,< 6",
+    "cyclonedx-python-lib >= 4,< 7",
     "html5lib>=1.1",
     "packaging>=23.0.0",                 # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "CacheControl[filecache] >= 0.13.0",
-    "cyclonedx-python-lib >= 4,< 7",
+    "cyclonedx-python-lib >= 5,< 7",
     "html5lib>=1.1",
     "packaging>=23.0.0",                 # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",


### PR DESCRIPTION
get_instance() has been renamed to make_outputter() and removed in 6.0.0.

Fixes #705.