### PR TITLE
Allow environment variables to set CLI defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* `pip-audit` now allows some CLI flags to be configured via environment
+  variables ([#755](https://github.com/pypa/pip-audit/pull/755))
+
 ## [2.7.3]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ with support from Google. This is not an official Google or Trail of Bits produc
   * [GitHub Actions](#github-actions)
   * [`pre-commit` support](#pre-commit-support)
 * [Usage](#usage)
+  * [Environment variables](#environment-variables)
   * [Exit codes](#exit-codes)
   * [Dry runs](#dry-runs)
 * [Examples](#examples)
@@ -217,6 +218,20 @@ optional arguments:
                         `--no-deps` flag has been provided (default: False)
 ```
 <!-- @end-pip-audit-help@ -->
+
+### Environment variables
+
+`pip-audit` allows users to configure some flags via environment variables
+instead:
+
+
+| Flag                      | Environment equivalent            | Example                               |
+| ------------------------- | --------------------------------- | ------------------------------------- |
+| `--format`                | `PIP_AUDIT_FORMAT`                | `PIP_AUDIT_FORMAT=markdown`           |
+| `--vulnerability-service` | `PIP_AUDIT_VULNERABILITY_SERVICE` | `PIP_AUDIT_VULNERABILITY_SERVICE=osv` |
+| `--desc`                  | `PIP_AUDIT_DESC`                  | `PIP_AUDIT_DESC=off`                  |
+| `--progress-spinner`      | `PIP_AUDIT_PROGRESS_SPINNER`      |  `PIP_AUDIT_PROGRESS_SPINNER=off`     |
+| `--output`                | `PIP_AUDIT_OUTPUT`                | `PIP_AUDIT_OUTPUT=/tmp/example`       |
 
 ### Exit codes
 

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -225,7 +225,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         "--format",
         type=OutputFormatChoice,
         choices=OutputFormatChoice,
-        default=OutputFormatChoice.Columns,
+        default=os.environ.get("PIP_AUDIT_FORMAT", OutputFormatChoice.Columns),
         metavar="FORMAT",
         help=_enum_help("the format to emit audit results in", OutputFormatChoice),
     )
@@ -234,7 +234,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         "--vulnerability-service",
         type=VulnerabilityServiceChoice,
         choices=VulnerabilityServiceChoice,
-        default=VulnerabilityServiceChoice.Pypi,
+        default=os.environ.get("PIP_AUDIT_VULNERABILITY_SERVICE", VulnerabilityServiceChoice.Pypi),
         metavar="SERVICE",
         help=_enum_help(
             "the vulnerability service to audit dependencies against",
@@ -260,7 +260,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         choices=VulnerabilityDescriptionChoice,
         nargs="?",
         const=VulnerabilityDescriptionChoice.On,
-        default=VulnerabilityDescriptionChoice.Auto,
+        default=os.environ.get("PIP_AUDIT_DESC", VulnerabilityDescriptionChoice.Auto),
         help="include a description for each vulnerability; "
         "`auto` defaults to `on` for the `json` format. This flag has no "
         "effect on the `cyclonedx-json` or `cyclonedx-xml` formats.",
@@ -285,7 +285,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         "--progress-spinner",
         type=ProgressSpinnerChoice,
         choices=ProgressSpinnerChoice,
-        default=ProgressSpinnerChoice.On,
+        default=os.environ.get("PIP_AUDIT_PROGRESS_SPINNER", ProgressSpinnerChoice.On),
         help="display a progress spinner",
     )
     parser.add_argument(
@@ -355,7 +355,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         type=Path,
         metavar="FILE",
         help="output results to the given file",
-        default="stdout",
+        default=os.environ.get("PIP_AUDIT_OUTPUT", "stdout"),
     )
     parser.add_argument(
         "--ignore-vuln",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 test = [
+    "cli-test-helpers",
     "coverage[toml] ~= 7.0, != 7.3.3", # https://github.com/nedbat/coveragepy/issues/1713
     "pretend",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 test = [
-    "cli-test-helpers",
     "coverage[toml] ~= 7.0, != 7.3.3", # https://github.com/nedbat/coveragepy/issues/1713
     "pretend",
     "pytest",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import pretend  # type: ignore
 import pytest
+from cli_test_helpers import ArgvContext, EnvironContext
 
 import pip_audit._cli
 from pip_audit._cli import (
@@ -215,3 +218,21 @@ def test_print_format(monkeypatch, vuln_count, pkg_count, skip_count, print_form
         pass
 
     assert bool(dummyformat.format.calls) == print_format
+
+
+def test_environment_variable():
+    """Environment variables set before execution change CLI option default."""
+    with ArgvContext("pip-audit"), EnvironContext(
+        PIP_AUDIT_DESC="off",
+        PIP_AUDIT_FORMAT="markdown",
+        PIP_AUDIT_OUTPUT="stderr",
+        PIP_AUDIT_PROGRESS_SPINNER="off",
+        PIP_AUDIT_VULNERABILITY_SERVICE="osv",
+    ):
+        args = pip_audit._cli._parser().parse_args()
+
+    assert args.desc == VulnerabilityDescriptionChoice.Off
+    assert args.format == OutputFormatChoice.Markdown
+    assert args.output == Path("stderr")
+    assert not args.progress_spinner
+    assert args.vulnerability_service == VulnerabilityServiceChoice.Osv


### PR DESCRIPTION
Adds a few environment variable getters that allow to override the default value of some CLI options.

Fixes #754