### PR TITLE
Many tests failing on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Improved handling of temporary files on Windows
+  ([#757](https://github.com/pypa/pip-audit/pull/757))
+
 ## [2.7.2]
 
 ### Fixed

--- a/pip_audit/_dependency_source/pyproject.py
+++ b/pip_audit/_dependency_source/pyproject.py
@@ -142,8 +142,8 @@ class PyProjectSource(DependencySource):
             # Now dump the new edited TOML to the temporary file.
             toml.dump(pyproject_data, tmp)
 
-            # And replace the original `pyproject.toml` file.
-            os.replace(tmp.name, self.filename)
+        # And replace the original `pyproject.toml` file.
+        os.replace(tmp.name, self.filename)
 
 
 class PyProjectSourceError(DependencySourceError):

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -5,7 +5,6 @@ Collect dependencies from one or more `requirements.txt`-formatted files.
 from __future__ import annotations
 
 import logging
-import os
 import re
 import shutil
 from contextlib import ExitStack

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -220,7 +220,7 @@ class RequirementSource(DependencySource):
         #
         # This time we're using the `RequirementsFile.parse` API instead of `Requirements.from_file`
         # since we want to access each line sequentially in order to rewrite the file.
-        reqs = list(RequirementsFile.parse(filename=str(filename)))
+        reqs = list(RequirementsFile.parse(filename=filename.as_posix()))
 
         # Check ahead of time for anything invalid in the requirements file since we don't want to
         # encounter this while writing out the file. Check for duplicate requirements and lines that

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -76,7 +76,7 @@ def dep_source(spec):
 @pytest.fixture(scope="session")
 def cache_dir():
     cache = tempfile.TemporaryDirectory()
-    yield cache.name
+    yield Path(cache.name)
     cache.cleanup()
 
 

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -379,7 +379,8 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
     def mock_replace(*_args, **_kwargs):
         raise OSError
 
-    monkeypatch.setattr(os, "replace", mock_replace)
+    from tempfile import _TemporaryFileWrapper
+    monkeypatch.setattr(_TemporaryFileWrapper, "seek", mock_replace, raising=False)
 
     source = requirement.RequirementSource(req_paths)
     with pytest.raises(DependencyFixError):

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from email.message import EmailMessage
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -559,6 +560,7 @@ def test_requirement_source_no_double_open(monkeypatch, req_file):
     assert ResolvedDependency("Flask", Version("2.0.1")) in specs
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="os.mkfifo does not exists on windows")
 def test_requirement_source_fifo():
     with TemporaryDirectory() as tmp_dir:
         fifo_path = Path(os.path.join(tmp_dir, "fifo"))

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -380,6 +380,7 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
         raise OSError
 
     from tempfile import _TemporaryFileWrapper
+
     monkeypatch.setattr(_TemporaryFileWrapper, "seek", mock_replace, raising=False)
 
     source = requirement.RequirementSource(req_paths)

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -376,12 +376,12 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
             f.write(input_req)
 
     # Simulate an error being raised during file recovery
-    def mock_replace(*_args, **_kwargs):
+    def mock_seek(*_args, **_kwargs):
         raise OSError
 
     from tempfile import _TemporaryFileWrapper
 
-    monkeypatch.setattr(_TemporaryFileWrapper, "seek", mock_replace, raising=False)
+    monkeypatch.setattr(_TemporaryFileWrapper, "seek", mock_seek, raising=False)
 
     source = requirement.RequirementSource(req_paths)
     with pytest.raises(DependencyFixError):

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -122,7 +122,7 @@ def test_requirement_source_git(req_file):
         [
             (
                 req_file(),
-                "git+https://github.com/benoitc/gunicorn.git@61ccfd6c38d477a908e0f376757bbb884438053a",
+                "git+https://github.com/pypa/sampleproject.git@5d277956b5a571dac16b28db74e5f2b780d9af5f",
             )
         ]
     )

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -128,7 +128,7 @@ def test_requirement_source_git(req_file):
     )
 
     specs = list(source.collect())
-    assert ResolvedDependency(name="gunicorn", version=Version("20.1.0")) in specs
+    assert ResolvedDependency(name="sampleproject", version=Version("3.0.0")) in specs
 
 
 @pytest.mark.online

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -121,13 +121,13 @@ def test_requirement_source_git(req_file):
         [
             (
                 req_file(),
-                "git+https://github.com/unbit/uwsgi.git@1bb9ad77c6d2d310c2d6d1d9ad62de61f725b824",
+                "git+https://github.com/benoitc/gunicorn.git@61ccfd6c38d477a908e0f376757bbb884438053a",
             )
         ]
     )
 
     specs = list(source.collect())
-    assert ResolvedDependency(name="uWSGI", version=Version("2.0.20")) in specs
+    assert ResolvedDependency(name="gunicorn", version=Version("20.1.0")) in specs
 
 
 @pytest.mark.online

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -10,14 +10,14 @@ from pip_audit._cache import _get_cache_dir, _get_pip_cache
 def test_get_cache_dir(monkeypatch):
     # When we supply a cache directory, always use that
     cache_dir = _get_cache_dir(Path("/tmp/foo/cache_dir"))
-    assert str(cache_dir) == "/tmp/foo/cache_dir"
+    assert cache_dir.as_posix() == "/tmp/foo/cache_dir"
 
-    get_pip_cache = pretend.call_recorder(lambda: "/fake/pip/cache/dir")
+    get_pip_cache = pretend.call_recorder(lambda: Path("/fake/pip/cache/dir"))
     monkeypatch.setattr(cache, "_get_pip_cache", get_pip_cache)
 
     # When `pip cache dir` works, we use it. In this case, it's mocked.
     cache_dir = _get_cache_dir(None, use_pip=True)
-    assert str(cache_dir) == "/fake/pip/cache/dir"
+    assert cache_dir.as_posix() == "/fake/pip/cache/dir"
 
 
 def test_get_pip_cache():
@@ -45,7 +45,7 @@ def test_get_cache_dir_old_pip(monkeypatch):
 
     # When we supply a cache directory, always use that
     cache_dir = _get_cache_dir(Path("/tmp/foo/cache_dir"))
-    assert str(cache_dir) == "/tmp/foo/cache_dir"
+    assert cache_dir.as_posix() == "/tmp/foo/cache_dir"
 
     # In this case, we can't query `pip` to figure out where its HTTP cache is
     # Instead, we use `~/.pip-audit-cache`

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -25,9 +25,9 @@ class TestOutputFormatChoice:
 
 
 class TestVulnerabilityServiceChoice:
-    def test_to_service_is_exhaustive(self):
+    def test_to_service_is_exhaustive(self, cache_dir):
         for choice in VulnerabilityServiceChoice:
-            assert choice.to_service(0, pretend.stub()) is not None
+            assert choice.to_service(0, cache_dir) is not None
 
     def test_str(self):
         for choice in VulnerabilityServiceChoice:


### PR DESCRIPTION
While testings for others PRs, I get a lot of `permissionError`. Windows does not like moving/replacing files if there aren't properly closed or another process is still on it.

I also get normalization problems on paths used in tests, so I enforced a posix format instead of a basic string cast.

