### PR TITLE
workflows/release: cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,10 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: ">= 3.8"
-        cache: "pip"
-        cache-dependency-path: pyproject.toml
-
+        python-version-file: pyproject.toml
 
     - name: deps
-      run: python -m pip install -U setuptools build wheel
+      run: python -m pip install -U build
 
     - name: build
       run: python -m build


### PR DESCRIPTION
Removes two unnecessary dependencies and disables the caching settings (which have only a marginal effect since our build setup is tiny, but represents a cache poisoning risk).

Also deduplicates the `python-version` setting by having `setup-python` pull it from `pyproject.toml` instead.