### PR TITLE
ci: zizmor: use uvx

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,14 +20,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Get zizmor
-        run: cargo install zizmor
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+
       - name: Run zizmor 🌈
-        run: zizmor --format sarif . > results.sarif
+        run: uvx zizmor --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   zizmor:
-    name: zizmor latest via Cargo
+    name: zizmor latest via PyPI
     runs-on: ubuntu-latest
     permissions:
       security-events: write


### PR DESCRIPTION
This takes the run from ~2 mins for compiling
to a few seconds (for the online audits).