### PR TITLE
pyproject: drop setuptools from lint dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '0 12 * * *'
 
+permissions: {}
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,16 +48,13 @@ test = [
 ]
 lint = [
     "ruff ~= 0.9",
-    # HACK(ww): interrogate needs setuptools to provide `pkg_resources` on Python 3.12+;
-    # remove this when https://github.com/econchick/interrogate/issues/164 is resolved.
-    "setuptools",
-    "interrogate",
+    "interrogate ~= 1.6",
     "mypy",
     "types-requests",
     "types-toml",
 ]
 doc = ["pdoc"]
-dev = ["build", "bump>=1.3.2", "pip-audit[doc,test,lint]"]
+dev = ["build", "pip-audit[doc,test,lint]"]
 
 [project.scripts]
 pip-audit = "pip_audit._cli:audit"


### PR DESCRIPTION
https://github.com/econchick/interrogate/issues/164 was fixed!

Also removes bump, since aren't using it for releases at the moment.