### PR TITLE
Remove two groups of resource leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All versions prior to 0.0.9 are untracked.
 * Auditing a fully-pinned requirements file with `--disable-pip` now allows for
   duplicates, so long as the duplicates don't have conflicting specifier sets
   ([#749](https://github.com/pypa/pip-audit/pull/749))
+* Fixed two sources of unnecessary resource leaks when doing file I/O
+  ([#878](https://github.com/pypa/pip-audit/pull/878))
 
 ## [2.7.3]
 

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -209,7 +209,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
     dep_source_args.add_argument(
         "-r",
         "--requirement",
-        type=argparse.FileType("r"),
+        type=Path,
         metavar="REQUIREMENT",
         action="append",
         dest="requirements",
@@ -465,9 +465,12 @@ def audit() -> None:  # pragma: no cover
 
         source: DependencySource
         if args.requirements is not None:
-            req_files: list[Path] = [Path(req.name) for req in args.requirements]
+            for req in args.requirements:
+                if not req.exists():
+                    _fatal(f"invalid requirements input: {req}")
+
             source = RequirementSource(
-                req_files,
+                args.requirements,
                 require_hashes=args.require_hashes,
                 no_deps=args.no_deps,
                 disable_pip=args.disable_pip,


### PR DESCRIPTION
This eliminates two groups of resource leaks:

1. Our `Popen(...)` wrapper wasn't closing pipe FDs correctly, since it incorrectly assumed that pipe PDs were closed by default. This was fixed by using it as a context manager instead.
2. Our CLI used `argparse.FileType` for `-r, --requirements`, which always leaks a FD. It uses `Path` instead now.

Fixes #877 (CC @LeamHall to test, if possible!)

Signed-off-by: William Woodruff <william@trailofbits.com>