### PR TITLE
test-cache: Fix XDG tests, make tests more consistent

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -20,8 +20,11 @@ def _patch_platformdirs(monkeypatch: MonkeyPatch, sys_platform: str) -> None:
     # as cache definition is stored in the top level `__init__.py` file of the
     # `platformdirs` package
     importlib.reload(platformdirs)
+    # Setting directory-controlling environment variables to known state
     if sys_platform == "win32":
         monkeypatch.setenv("LOCALAPPDATA", "/tmp/AppData/Local")
+    elif sys_platform == "linux":
+        monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/home/.cache")
 
 
 def test_get_cache_dir(monkeypatch):
@@ -48,7 +51,7 @@ def test_get_pip_cache():
     [
         pytest.param(
             "linux",
-            Path.home() / ".cache" / "pip-audit",
+            Path("/tmp") / "home" / ".cache" / "pip-audit",
             id="on Linux",
         ),
         pytest.param(
@@ -76,7 +79,7 @@ def test_get_cache_dir_do_not_use_pip(monkeypatch, sys_platform, expected):
     [
         pytest.param(
             "linux",
-            Path.home() / ".cache" / "pip-audit",
+            Path("/tmp") / "home" / ".cache" / "pip-audit",
             id="on Linux",
         ),
         pytest.param(
@@ -105,7 +108,7 @@ def test_get_cache_dir_pip_disabled_in_environment(monkeypatch, sys_platform, ex
     [
         pytest.param(
             "linux",
-            Path.home() / ".cache" / "pip-audit",
+            Path("/tmp") / "home" / ".cache" / "pip-audit",
             id="on Linux",
         ),
         pytest.param(

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -29,15 +29,15 @@ def _patch_platformdirs(monkeypatch: MonkeyPatch, sys_platform: str) -> None:
 
 def test_get_cache_dir(monkeypatch):
     # When we supply a cache directory, always use that
-    cache_dir = _get_cache_dir(Path("/tmp/foo/cache_dir"))
-    assert cache_dir.as_posix() == "/tmp/foo/cache_dir"
+    cache_dir = Path("/tmp/foo/cache_dir")
+    assert _get_cache_dir(cache_dir) == cache_dir
 
-    get_pip_cache = pretend.call_recorder(lambda: Path("/fake/pip/cache/dir"))
+    cache_dir = Path("/fake/pip/cache/dir")
+    get_pip_cache = pretend.call_recorder(lambda: cache_dir)
     monkeypatch.setattr(cache, "_get_pip_cache", get_pip_cache)
 
     # When `pip cache dir` works, we use it. In this case, it's mocked.
-    cache_dir = _get_cache_dir(None, use_pip=True)
-    assert cache_dir.as_posix() == "/fake/pip/cache/dir"
+    assert _get_cache_dir(None, use_pip=True) == cache_dir
 
 
 def test_get_pip_cache():
@@ -69,9 +69,9 @@ def test_get_pip_cache():
 def test_get_cache_dir_do_not_use_pip(monkeypatch, sys_platform, expected):
     # Check cross-platforms
     _patch_platformdirs(monkeypatch, sys_platform)
+
     # Even with None, we never use the pip cache if we're told not to.
-    cache_dir = _get_cache_dir(None, use_pip=False)
-    assert cache_dir == expected
+    assert _get_cache_dir(None, use_pip=False) == expected
 
 
 @pytest.mark.parametrize(
@@ -129,14 +129,9 @@ def test_get_cache_dir_old_pip(monkeypatch, sys_platform, expected):
     # Check cross-platforms
     _patch_platformdirs(monkeypatch, sys_platform)
 
-    # When we supply a cache directory, always use that
-    cache_dir = _get_cache_dir(Path("/tmp/foo/cache_dir"))
-    assert cache_dir.as_posix() == "/tmp/foo/cache_dir"
-
     # In this case, we can't query `pip` to figure out where its HTTP cache is
     # Instead, we use `~/.pip-audit-cache`
-    cache_dir = _get_cache_dir(None)
-    assert cache_dir == expected
+    assert _get_cache_dir(None) == expected
 
 
 def test_cache_warns_about_old_pip(monkeypatch, cache_dir):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -27,7 +27,18 @@ def _patch_platformdirs(monkeypatch: MonkeyPatch, sys_platform: str) -> None:
         monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/home/.cache")
 
 
-def test_get_cache_dir(monkeypatch):
+@pytest.mark.parametrize(
+    "sys_platform",
+    [
+        pytest.param("linux", id="on Linux"),
+        pytest.param("win32", id="on Windows"),
+        pytest.param("darwin", id="on MacOS"),
+    ],
+)
+def test_get_cache_dir(monkeypatch, sys_platform):
+    # Check cross-platforms
+    _patch_platformdirs(monkeypatch, sys_platform)
+
     # When we supply a cache directory, always use that
     cache_dir = Path("/tmp/foo/cache_dir")
     assert _get_cache_dir(cache_dir) == cache_dir


### PR DESCRIPTION
Solving the issues I raised in
https://github.com/pypa/pip-audit/pull/814#issuecomment-2646555094, this commit
set (at least on my machine) fixes the tests on Linux systems with custom XDG
variables.

While I was there, I noticed the tests were a little inconsistent, so this PR
also contains a couple of commits addressing that. Three of the changes I'm
unsure about, so I'd appreciate a second look at them before this is merged.

- **fix(test_cache): Correct XDG testing logic**

  The tests on Linux were relying on XDG_CACHE_HOME being set to its fallback
  value of `∼/.cache`, which made them fail on systems with custom values for
  `XDG_CACHE_HOME`.

  To account for this, we take the cue from the Windows tests and set
  `XDG_CACHE_HOME` to a known, custom, value. This incidentally also tests that
  our logic can account for custom values of `XDG_CACHE_HOME`, so this doesn't
  need its own test.

  The value of `/tmp/home/.cache` was chosen as a cross between the Windows
  value of `/tmp/AppData/Local` and the fallback `∼/.cache`

  (This commit is a MVP for the PR, the others can be ignored if desired)

  Fixes: #814

- **RFC: fix(test_cache): Make tests more consistent**
  - `test_get_cache_dir`: Follow all other tests in not casting to posix paths
    in checking paths are as expected, instead checking an equal Path object is
    roundtripped. NOTE: This edit I'm least confident in, not least since I
    don't have a Windows machine available to test this on.
  - `test_get_cache_dir_old_pip`: Remove logic checking whether _get_cache_dir
    accepts explicitly-set paths. It is duplicated from `test_get_cache_dir`,
    doesn't appear to be exercising any new codepath, and it is unclear why this
    case needs extra exercise
  - `test_get_pip_cache`, `test_get_cache_dir_old_pip`: follow the lead of
    `test_get_cache_dir_pip_disabled_in_environment` and inline the call to
    `_get_cache_dir`
- **RFC: fix(test_cache): Cross-OS test_get_cache_dir**

  In view of my doubts above in re whether I broke `test_get_cache_dir` on
  Windows, run the test simulating all platforms. However, I am unsure that my
  understanding of `pathlib` and the relevant monkeypatching is correct, or if
  this commit is even needed.
