### PR TITLE
Implement helper to create `VulnerabilityResult`

### DIFF
--- a/pip_audit/_service/esms.py
+++ b/pip_audit/_service/esms.py
@@ -28,14 +28,6 @@ from pip_audit._service.interface import (
 logger = logging.getLogger(__name__)
 
 
-def _id_comparison_key(id: str) -> int:
-    if id.startswith("PYSEC"):
-        return 1
-    elif id.startswith("CVE"):
-        return 2
-    return 3
-
-
 class EcosystemsService(VulnerabilityService):
     """
     An implementation of `VulnerabilityService` that uses Ecosyste.ms to provide Python
@@ -100,7 +92,6 @@ class EcosystemsService(VulnerabilityService):
         for vuln in response_json:
             # Get the IDs, prioritising PYSEC and CVE.
             ids: list[VulnerabilityID] = vuln["identifiers"]
-            ids.sort(key=_id_comparison_key)
 
             # If the vulnerability has been withdrawn, we skip it entirely.
             withdrawn_at = vuln["withdrawn_at"]
@@ -153,11 +144,10 @@ class EcosystemsService(VulnerabilityService):
                 continue
 
             results.append(
-                VulnerabilityResult(
-                    id=ids[0],
+                VulnerabilityResult.create(
+                    ids=ids,
                     description=description,
                     fix_versions=sorted(fix_versions),
-                    aliases=set(ids[1:]),
                     published=self._parse_rfc3339(vuln.get("published")),
                 )
             )

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -150,11 +150,10 @@ class OsvService(VulnerabilityService):
             fix_versions.sort()
 
             results.append(
-                VulnerabilityResult(
-                    id=id,
+                VulnerabilityResult.create(
+                    ids=[id, *vuln.get("aliases", [])],
                     description=description,
                     fix_versions=fix_versions,
-                    aliases=set(vuln.get("aliases", [])),
                     published=self._parse_rfc3339(vuln.get("published")),
                 )
             )

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -125,11 +125,10 @@ class PyPIService(VulnerabilityService):
             description = description.replace("\n", " ")
 
             results.append(
-                VulnerabilityResult(
-                    id=id,
+                VulnerabilityResult.create(
+                    ids=[id, *v["aliases"]],
                     description=description,
                     fix_versions=fix_versions,
-                    aliases=set(v["aliases"]),
                     published=self._parse_rfc3339(v.get("published")),
                 )
             )

--- a/test/service/test_interface.py
+++ b/test/service/test_interface.py
@@ -1,4 +1,6 @@
 import datetime
+import random
+from typing import cast
 
 import pytest
 from packaging.version import Version
@@ -7,6 +9,7 @@ from pip_audit._service.interface import (
     Dependency,
     ResolvedDependency,
     SkippedDependency,
+    VulnerabilityID,
     VulnerabilityResult,
     VulnerabilityService,
 )
@@ -82,6 +85,21 @@ def test_vulnerability_result_has_any_id():
     assert result.has_any_id({"ham", "eggs", "BAZ"})
     assert not result.has_any_id({"zilch"})
     assert not result.has_any_id(set())
+
+
+@pytest.mark.parametrize("_n", range(10))
+def test_vulnerability_result_create(_n):
+    ids = cast(
+        list[VulnerabilityID],
+        ["testid1", "testid2", "GHSA-XXXX-XXXXX", "CVE-XXXX-XXXXX", "PYSEC-XXXX-XXXXX"],
+    )
+    random.shuffle(ids)
+
+    result = VulnerabilityResult.create(ids, "foo", [], None)
+
+    assert result.id == "PYSEC-XXXX-XXXXX"
+    ids.remove(VulnerabilityID("PYSEC-XXXX-XXXXX"))
+    assert result.aliases == set(ids)
 
 
 class TestVulnerabilityService:


### PR DESCRIPTION
Depends on #903.

This takes `ids`, `description`, `fix_versions`, and `published` and
splits `ids` into `id` and aliases as appropriate internally. Priority
is given to PYSEC and CVE identifiers for `id`.