### PR TITLE
fix: use tomli to parse toml file, prevent decode error for new toml syntax

### DIFF
--- a/pip_audit/_dependency_source/pylock.py
+++ b/pip_audit/_dependency_source/pylock.py
@@ -47,7 +47,7 @@ class PyLockSource(DependencySource):
         Raises a `PyLockSourceError` on any errors.
         """
         try:
-            with open(filename, "rb") as f:
+            with filename.open(mode="rb") as f:
                 pylock = tomli.load(f)
         except tomli.TOMLDecodeError as e:
             raise PyLockSourceError(f"{filename}: invalid TOML in lockfile") from e

--- a/pip_audit/_dependency_source/pylock.py
+++ b/pip_audit/_dependency_source/pylock.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import toml
+import tomli
 from packaging.version import Version
 
 from pip_audit._dependency_source import DependencyFixError, DependencySource, DependencySourceError
@@ -47,8 +47,9 @@ class PyLockSource(DependencySource):
         Raises a `PyLockSourceError` on any errors.
         """
         try:
-            pylock = toml.load(filename)
-        except toml.TomlDecodeError as e:
+            with open(filename, "rb") as f:
+                pylock = tomli.load(f)
+        except tomli.TOMLDecodeError as e:
             raise PyLockSourceError(f"{filename}: invalid TOML in lockfile") from e
 
         lock_version = pylock.get("lock-version")

--- a/pip_audit/_dependency_source/pyproject.py
+++ b/pip_audit/_dependency_source/pyproject.py
@@ -10,7 +10,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-import toml
+import tomli
+import tomli_w
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 
@@ -60,8 +61,8 @@ class PyProjectSource(DependencySource):
         Raises a `PyProjectSourceError` on any errors.
         """
 
-        with self.filename.open("r") as f:
-            pyproject_data = toml.load(f)
+        with self.filename.open("rb") as f:
+            pyproject_data = tomli.load(f)
 
             project = pyproject_data.get("project")
             if project is None:
@@ -109,8 +110,8 @@ class PyProjectSource(DependencySource):
         Fixes a dependency version for this `PyProjectSource`.
         """
 
-        with self.filename.open("r+") as f, NamedTemporaryFile(mode="r+", delete=False) as tmp:
-            pyproject_data = toml.load(f)
+        with self.filename.open("rb+") as f, NamedTemporaryFile(mode="rb+", delete=False) as tmp:
+            pyproject_data = tomli.load(f)
 
             project = pyproject_data.get("project")
             if project is None:
@@ -141,7 +142,7 @@ class PyProjectSource(DependencySource):
                 assert req.marker is None or req.marker.evaluate()
 
             # Now dump the new edited TOML to the temporary file.
-            toml.dump(pyproject_data, tmp)
+            tomli_w.dump(pyproject_data, tmp)
 
         # And replace the original `pyproject.toml` file.
         os.replace(tmp.name, self.filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "pip-requirements-parser>=32.0.0",
     "requests >= 2.31.0",
     "rich >= 12.4",
-    "toml >= 0.10",
+    "tomli >= 2.2.1",
+    "tomli-w >= 1.2.0",
     "platformdirs >= 4.2.0",
 ]
 requires-python = ">=3.9"

--- a/test/dependency_source/test_pyproject.py
+++ b/test/dependency_source/test_pyproject.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pretend  # type: ignore
 import pytest
-import toml
+import tomli
 from packaging.version import Version
 
 from pip_audit._dependency_source import (
@@ -25,8 +25,8 @@ def _init_pyproject(filename: Path, contents: str) -> pyproject.PyProjectSource:
 
 
 def _check_file(filename: Path, expected_contents: dict) -> None:
-    with open(filename) as f:
-        assert toml.load(f) == expected_contents
+    with open(filename, "rb") as f:
+        assert tomli.load(f) == expected_contents
 
 
 @pytest.mark.online


### PR DESCRIPTION
## Why:

If the pyproject.toml contain some new syntax ak the dictionnary inside a list, the actual toml lib used by pip audit fail to parse the line and raise `IndexError`

Example who not work with `toml` library.
```toml
commands = [["poetry", "run", "pytest", {replace = "posargs", default = [], extend=true}]]
```

## How:

Change with `tomli` and `tomli_w` for the dump part.