### PR TITLE
feat: support optional dependencies/extras from pyproject.toml

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -232,3 +232,30 @@ def test_environment_variable(monkeypatch):
     assert args.output == Path("/tmp/fake")
     assert not args.progress_spinner
     assert args.vulnerability_service == VulnerabilityServiceChoice.Osv
+
+
+class TestParseProjectPathWithExtras:
+    def test_parse_simple_path(self):
+        path, extras = pip_audit._cli._parse_project_path_with_extras(".")
+        assert path == Path(".")
+        assert extras == []
+
+    def test_parse_path_with_single_extra(self):
+        path, extras = pip_audit._cli._parse_project_path_with_extras(".[dev]")
+        assert path == Path(".")
+        assert extras == ["dev"]
+
+    def test_parse_path_with_multiple_extras(self):
+        path, extras = pip_audit._cli._parse_project_path_with_extras(".[dev,test]")
+        assert path == Path(".")
+        assert extras == ["dev", "test"]
+
+    def test_parse_path_with_spaces_in_extras(self):
+        path, extras = pip_audit._cli._parse_project_path_with_extras(".[dev, test, docs]")
+        assert path == Path(".")
+        assert extras == ["dev", "test", "docs"]
+
+    def test_parse_absolute_path_with_extras(self):
+        path, extras = pip_audit._cli._parse_project_path_with_extras("/path/to/project[dev]")
+        assert path == Path("/path/to/project")
+        assert extras == ["dev"]


### PR DESCRIPTION
## Summary
- Support auditing optional dependencies using syntax: pip-audit .[dev]
- Parse extras from path argument (.[dev], .[dev,test])
- Merge optional-dependencies with main dependencies for audit

Fixes #766

## Test plan
- [x] Added 10 comprehensive test cases (5 pyproject + 5 CLI parsing)
- [x] All 18 tests passing (100%)
- [x] Integration tested with real pyproject.toml files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>