### PR TITLE
Validate --output before running the audit

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -53,6 +53,34 @@ package_logger = logging.getLogger("pip_audit")
 package_logger.setLevel(os.environ.get("PIP_AUDIT_LOGLEVEL", "INFO").upper())
 
 
+def _is_stdout(name: Path) -> bool:
+    return str(name) in {"stdout", "-"}
+
+
+def _check_output_writable(name: Path) -> str | None:
+    """
+    Return a reason why `--output` cannot be written to, or `None` if it can.
+
+    Creation stays deferred (see `_output_io`), so this only inspects the
+    parent directory. It is called before the audit starts: without it, a
+    mistyped path is reported after every dependency has been queried, and
+    the results of that work are lost.
+    """
+    if _is_stdout(name):
+        return None
+
+    parent = name.parent if str(name.parent) else Path(".")
+    if not parent.exists():
+        return f"no such directory: {parent}"
+    if not parent.is_dir():
+        return f"not a directory: {parent}"
+    if name.exists() and name.is_dir():
+        return f"is a directory: {name}"
+    if not os.access(parent, os.W_OK):
+        return f"directory is not writable: {parent}"
+    return None
+
+
 @contextmanager
 def _output_io(name: Path) -> Iterator[IO[str]]:  # pragma: no cover
     """
@@ -60,10 +88,16 @@ def _output_io(name: Path) -> Iterator[IO[str]]:  # pragma: no cover
     to avoid `argparse.FileType`'s "eager" file creation, which is generally
     the wrong/unexpected behavior when dealing with fallible processes.
     """
-    if str(name) in {"stdout", "-"}:
+    if _is_stdout(name):
         yield sys.stdout
     else:
-        with name.open("w") as io:
+        try:
+            io = name.open("w")
+        except OSError as e:
+            # The audit has already run by this point, so this is the last
+            # chance to say something useful rather than raise.
+            _fatal(f"can't write to {name}: {e.strerror or e}")
+        with io:
             yield io
 
 
@@ -444,6 +478,12 @@ def audit() -> None:  # pragma: no cover
     """
     parser = _parser()
     args = _parse_args(parser)
+
+    # Checked before any auditing so a mistyped path costs nothing. The file
+    # itself is still created only once there is something to write into it.
+    output_problem = _check_output_writable(args.output)
+    if output_problem is not None:
+        parser.error(f"argument -o/--output: {output_problem}")
 
     service: VulnerabilityService
     if args.vulnerability_service is VulnerabilityServiceChoice.Osv:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -232,3 +232,44 @@ def test_environment_variable(monkeypatch):
     assert args.output == Path("/tmp/fake")
     assert not args.progress_spinner
     assert args.vulnerability_service == VulnerabilityServiceChoice.Osv
+
+
+class TestCheckOutputWritable:
+    """`--output` is validated before the audit runs.
+
+    Without this, a mistyped path surfaced only after every dependency had
+    been queried, as an uncaught FileNotFoundError, and the results of that
+    work were lost.
+    """
+
+    @pytest.mark.parametrize("name", ["stdout", "-"])
+    def test_stdout_is_always_writable(self, name):
+        assert pip_audit._cli._check_output_writable(Path(name)) is None
+
+    def test_new_file_in_an_existing_directory(self, tmp_path):
+        assert pip_audit._cli._check_output_writable(tmp_path / "out.json") is None
+
+    def test_existing_file_is_writable(self, tmp_path):
+        out = tmp_path / "out.json"
+        out.write_text("stale")
+        assert pip_audit._cli._check_output_writable(out) is None
+
+    def test_bare_filename_uses_the_current_directory(self):
+        assert pip_audit._cli._check_output_writable(Path("out.json")) is None
+
+    def test_missing_directory(self, tmp_path):
+        reason = pip_audit._cli._check_output_writable(tmp_path / "nope" / "out.json")
+        assert reason is not None
+        assert "no such directory" in reason
+
+    def test_parent_is_a_file(self, tmp_path):
+        parent = tmp_path / "afile"
+        parent.write_text("")
+        reason = pip_audit._cli._check_output_writable(parent / "out.json")
+        assert reason is not None
+        assert "not a directory" in reason
+
+    def test_output_is_a_directory(self, tmp_path):
+        reason = pip_audit._cli._check_output_writable(tmp_path)
+        assert reason is not None
+        assert "is a directory" in reason


### PR DESCRIPTION
## Summary

An unwritable `--output` path is discovered only when the results are written — which is after every dependency has been queried — and it surfaces as an uncaught traceback:

```console
$ pip-audit -r requirements.txt --output nope/out.json --format json
Found 3 known vulnerabilities in 1 package
Traceback (most recent call last):
  ...
  File "pip_audit/_cli.py", line 66, in _output_io
    with name.open("w") as io:
         ^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'nope/out.json'
```

Two things go wrong there:

1. **The audit's work is thrown away.** Everything up to the write succeeded; the results existed and are lost, having cost however long the network took.
2. **It is reported as a crash.** This CLI reports every other failure through `parser.error` or `_fatal`, so a mistyped path reads like a bug in pip-audit rather than a bug in the command line.

Same traceback for a parent that is a file, and for an `--output` that is itself a directory.

## What this changes

The parent directory is checked up front, alongside the existing argument validation in `audit()`:

```console
$ pip-audit -r requirements.txt --output nope/out.json --format json
pip-audit: error: argument -o/--output: no such directory: nope
```

That returns immediately, before any dependency is resolved.

The deliberate choice **not** to create the file eagerly is kept — the comment on `_output_io` explains why, and I did not want to trade that away. `_output_io` still opens the file only when there is something to write, so a failed audit leaves no empty file behind. Its `open` is now wrapped too, because a path can stop being writable between the check and the write.

`stdout` and `-` are unaffected.

## Tests

`TestCheckOutputWritable` covers the three cases that used to traceback (missing directory, parent is a file, output is a directory) and the four that must keep working (`stdout`, `-`, a new file in an existing directory, an existing file, and a bare filename in the current directory).

Locally, the full suite passes: 247 passed, 1 skipped. `ruff format --check`, `ruff check`, `mypy pip_audit` and `interrogate` all clean.

## Note

This is adjacent to #415 (`--requirement -` reporting a raw `No such file or directory`) — the same family of raw filesystem errors reaching the user. I have not touched that path here.
